### PR TITLE
StateObject creation with wrappedValue

### DIFF
--- a/swiftui-expert-skill/references/state-management.md
+++ b/swiftui-expert-skill/references/state-management.md
@@ -150,15 +150,16 @@ struct GoodView: View {
 }
 ```
 
-### $StateObject instantiation in View's initializer
+### @StateObject instantiation in View's initializer
 
-If your $StateObject creation from wrapper depends on parameters passed in initializer, be aware of redundant allocations and hidden side effects. Kudos to Vincent Pradeilles.
+If you need to create a @StateObject with initialization parameters in your view's custom initializer, be aware of redundant allocations and hidden side effects. Kudos to Vincent Pradeilles.
 
 ```swift
-// WRONG - creates new ViewModel instance on every view update
+// WRONG - creates a new ViewModel instance each time the view's initializer is called
+// (which can happen multiple times during SwiftUI's structural identity evaluation)
 struct MovieDetailsView: View {
     
-    @StateObject var viewModel: MovieDetailsViewModel
+    @StateObject private var viewModel: MovieDetailsViewModel
     
     init(movie: Movie) {
         let viewModel = MovieDetailsViewModel(movie: movie)
@@ -170,10 +171,10 @@ struct MovieDetailsView: View {
     }
 }
 
-// CORRECT - creation in @autoclosure prevents from multiple instantiations
+// CORRECT - creation in @autoclosure prevents multiple instantiations
 struct MovieDetailsView: View {
     
-    @StateObject var viewModel: MovieDetailsViewModel
+    @StateObject private var viewModel: MovieDetailsViewModel
     
     init(movie: Movie) {
         _viewModel = StateObject(


### PR DESCRIPTION
When you need to create StateObject from wrapper which relies on DI values (either in constructor or in method), it should avoid objects creation out of auto-closure.

This was highlighted by Vincent Pradeilles: https://www.linkedin.com/in/vincentpradeilles/overlay/about-this-profile/