### PR TITLE
Update GitHub Actions workflow to use the current branch reference

### DIFF
--- a/.github/workflows/sync-readme-references.yml
+++ b/.github/workflows/sync-readme-references.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
This will fix the workflow for updating references.