### PR TITLE
Update marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,8 +44,7 @@
       "source": "./",
       "skills": [
         "./swiftui-expert-skill"
-      ],
-      "strict": false
+      ]
     }
   ]
 }


### PR DESCRIPTION
to resolve error when installing via Claude Code

 Plugin Errors                                                                                                                            
 └ 1 plugin error(s) detected:                                                                                                            
   └ swiftui-expert@swiftui-expert-skill: Plugin swiftui-expert has conflicting manifests: both plugin.json and marketplace entry specify 
  components. Set strict: true in marketplace entry or remove component specs from one location.