### PR TITLE
StateObject anti-pattern info

### DIFF
--- a/swiftui-expert-skill/references/state-management.md
+++ b/swiftui-expert-skill/references/state-management.md
@@ -150,7 +150,7 @@ struct GoodView: View {
 }
 ```
 
-### @StateObject instantiation in View's initializer
+### @StateObject instantiation in View's initializer (if it's a Parent view)
 
 This approach is an anti-pattern in general. Prefer storing the StateObject in the parent view or wherever the model is actually owned, then pass it down (use @ObservedObject, @EnvironmentObject, or @Bindable (for @Observable)) to keep ownership and lifecycle explicit.
 If you need to create a @StateObject with initialization parameters in your view's custom initializer, be aware of redundant allocations and hidden side effects.


### PR DESCRIPTION
From discussion in previous PR: https://github.com/AvdLee/SwiftUI-Agent-Skill/pull/7

Need to highlight in Skill that using such init, in general, is not very good pattern and breaks the logical scope.

CC @malhal