### PR TITLE
Remove unnecessary skills entry from marketplace.json configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,10 +41,7 @@
         "performance",
         "liquid-glass"
       ],
-      "source": "./",
-      "skills": [
-        "./swiftui-expert-skill"
-      ]
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
The reported conflict between plugin.json and marketplace.json defining skills in two places is no longer a runtime error with current Claude Code versions. The strict field on marketplace plugin entries now defaults to true, which means component fields from both files are merged rather than conflicting.

However, the duplication is redundant and should be cleaned up for clarity and to prevent confusion for users on older Claude Code versions.

Related to #17 and #20