### PR TITLE
docs(state-management): add @FocusState guidance for single vs multi-field forms

### DIFF
--- a/swiftui-expert-skill/references/state-management.md
+++ b/swiftui-expert-skill/references/state-management.md
@@ -107,8 +107,7 @@ Use `@FocusState` to control text input focus in SwiftUI. Choose the focus value
 ### Bool vs enum
 
 - Use `@FocusState private var isFocused: Bool` when the view has a single focusable field.
-- Use a `Hashable` enum optional value for multiple fields.
-- Prefer an enum for readability and type safety when fields are known in advance.
+- Use a `Hashable` enum optional value for multiple fields, for better readability and type safety.
 
 ### Single Field: Bool
 


### PR DESCRIPTION
Adds `@FocusState` guidance to the SwiftUI state management reference, covering when to use:
- Bool focus state for a single field
- enum-backed focus state for multiple fields in the same view

### What Changed

- Added a new `@FocusState` section to [state-management.md](app://-/index.html#)

Included examples for:
- Single-field focus with `@FocusState` Bool
- Multi-field focus with `@FocusState` Field? using a Hashable enum

### Why
This fills a gap in the current state management reference with practical SwiftUI-specific guidance for focus handling, especially for form views with multiple inputs.

### Test Notes
Docs-only change; no runtime tests required.