### PR TITLE
Add maintenance skill to update SwiftUI API deprecations

### DIFF
--- a/.agents/skills/update-swiftui-apis/SKILL.md
+++ b/.agents/skills/update-swiftui-apis/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: update-swiftui-apis
+description: Scan Apple's SwiftUI documentation for deprecated APIs and update the SwiftUI Expert Skill with modern replacements. Use when asked to "update latest APIs", "refresh deprecated SwiftUI APIs", "check for new SwiftUI deprecations", "scan for API changes", or after a new iOS/Xcode release. Requires the Sosumi MCP to be available.
+---
+
+# Update SwiftUI APIs
+
+Systematically scan Apple's developer documentation via the Sosumi MCP, identify deprecated SwiftUI APIs and their modern replacements, and update `swiftui-expert-skill/references/latest-apis.md`.
+
+## Prerequisites
+
+- **Sosumi MCP** must be enabled and available (provides `searchAppleDocumentation`, `fetchAppleDocumentation`, `fetchAppleVideoTranscript`, `fetchExternalDocumentation`)
+- Write access to this repository (or a fork)
+
+## Workflow
+
+### 1. Understand current coverage
+
+Read `swiftui-expert-skill/references/latest-apis.md` to understand:
+- Which deprecated-to-modern transitions are already documented
+- The version segments in use (iOS 15+, 16+, 17+, 18+, 26+)
+- The Quick Lookup Table at the bottom
+
+### 2. Load the scan manifest
+
+Read `references/scan-manifest.md` (relative to this skill). It contains the categorized list of API areas, documentation paths, search queries, and WWDC video paths to scan.
+
+### 3. Scan Apple documentation
+
+For each category in the manifest:
+
+1. Call `searchAppleDocumentation` with the listed queries to discover relevant pages.
+2. Call `fetchAppleDocumentation` with specific documentation paths to get full API details.
+3. Look for deprecation notices, "Deprecated" labels, and "Use ... instead" guidance.
+4. Note the iOS version where the modern replacement became available.
+5. Optionally call `fetchAppleVideoTranscript` for WWDC sessions that announce API changes.
+
+Batch related searches together for efficiency. Focus on finding **new** deprecations not yet in `latest-apis.md`.
+
+### 4. Compare and identify changes
+
+Compare findings against existing entries. Categorize results:
+- **New deprecations**: APIs not yet documented in `latest-apis.md`
+- **Corrections**: Existing entries that need updating (wrong version, better replacement available)
+- **New version segments**: If a new iOS version introduces deprecations, add a new section
+
+### 5. Update latest-apis.md
+
+Follow the established format exactly. Each entry must include:
+
+**Section placement** -- place under the correct version segment:
+- "Always Use (iOS 15+)" for long-deprecated APIs
+- "When Targeting iOS 16+" / "17+" / "18+" / "26+" for version-gated changes
+
+**Entry format:**
+
+```markdown
+**Always use `modernAPI()` instead of `deprecatedAPI()`.**
+
+\```swift
+// Modern
+View()
+    .modernAPI()
+
+// Deprecated
+View()
+    .deprecatedAPI()
+\```
+```
+
+**Quick Lookup Table** -- add a row at the bottom of the file:
+
+```markdown
+| `deprecatedAPI()` | `modernAPI()` | iOS XX+ |
+```
+
+Keep the attribution line at the top of the file:
+> Based on a comparison of Apple's documentation using the Sosumi MCP, we found the latest recommended APIs to use.
+
+### 6. Open a pull request
+
+1. Create a branch from `main` named `update/latest-apis-YYYY-MM` (use current year and month).
+2. Commit changes to `swiftui-expert-skill/references/latest-apis.md`.
+3. Open a PR via `gh pr create` with:
+   - **Title**: "Update latest SwiftUI APIs (Month Year)"
+   - **Body**: Summary of new/changed entries, attribution to Sosumi MCP
+
+## Sosumi MCP Tool Reference
+
+| Tool | Parameters | Returns |
+|------|-----------|---------|
+| `searchAppleDocumentation` | `query` (string) | JSON with `results[]` containing `title`, `url`, `description`, `breadcrumbs`, `tags`, `type` |
+| `fetchAppleDocumentation` | `path` (string, e.g. `/documentation/swiftui/view/foregroundstyle(_:)`) | Markdown documentation content |
+| `fetchAppleVideoTranscript` | `path` (string, e.g. `/videos/play/wwdc2025/10133`) | Markdown transcript |
+| `fetchExternalDocumentation` | `url` (string, full https URL) | Markdown documentation content |
+
+## Tips
+
+- Start broad with `searchAppleDocumentation` queries, then drill into specific paths with `fetchAppleDocumentation`.
+- Apple's deprecation docs typically say "Deprecated" in the page and link to the replacement.
+- WWDC "What's new in SwiftUI" sessions are the best source for newly introduced replacements.
+- When unsure about the exact iOS version for a deprecation, verify by checking the "Availability" section in the fetched documentation.
+- If an API is deprecated but no direct replacement exists, note this rather than suggesting an incorrect alternative.

--- a/.agents/skills/update-swiftui-apis/references/scan-manifest.md
+++ b/.agents/skills/update-swiftui-apis/references/scan-manifest.md
@@ -1,0 +1,230 @@
+# SwiftUI API Scan Manifest
+
+Categorized list of API areas to scan via the Sosumi MCP. For each category: search queries to run, documentation paths to fetch, and WWDC sessions to check.
+
+Add new categories or paths as Apple introduces new APIs.
+
+---
+
+## Navigation
+
+**Search queries:**
+- `SwiftUI NavigationStack`
+- `SwiftUI NavigationSplitView`
+- `SwiftUI navigationTitle`
+- `SwiftUI toolbar`
+- `SwiftUI NavigationLink deprecated`
+
+**Documentation paths:**
+- `/documentation/swiftui/navigationstack`
+- `/documentation/swiftui/navigationsplitview`
+- `/documentation/swiftui/navigationlink`
+- `/documentation/swiftui/view/navigationtitle(_:)-avgj`
+- `/documentation/swiftui/view/toolbar(content:)-5w0tj`
+- `/documentation/swiftui/view/toolbarvisibility(_:for:)`
+
+---
+
+## Appearance & Styling
+
+**Search queries:**
+- `SwiftUI foregroundStyle`
+- `SwiftUI foregroundColor deprecated`
+- `SwiftUI tint modifier`
+- `SwiftUI preferredColorScheme`
+- `SwiftUI clipShape`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/foregroundstyle(_:)`
+- `/documentation/swiftui/view/foregroundcolor(_:)`
+- `/documentation/swiftui/view/tint(_:)-93mfq`
+- `/documentation/swiftui/view/preferredcolorscheme(_:)`
+- `/documentation/swiftui/view/clipshape(_:style:)`
+
+---
+
+## State Management
+
+**Search queries:**
+- `SwiftUI Observable macro`
+- `SwiftUI ObservableObject deprecated`
+- `SwiftUI Bindable`
+- `SwiftUI State`
+- `SwiftUI Entry macro`
+
+**Documentation paths:**
+- `/documentation/observation/observable()`
+- `/documentation/swiftui/observableobject`
+- `/documentation/swiftui/bindable`
+- `/documentation/swiftui/state`
+- `/documentation/swiftui/entry()`
+- `/documentation/swiftui/environmentvalues`
+
+---
+
+## Presentation & Alerts
+
+**Search queries:**
+- `SwiftUI alert modifier`
+- `SwiftUI confirmationDialog`
+- `SwiftUI actionSheet deprecated`
+- `SwiftUI sheet modifier`
+- `SwiftUI fullScreenCover`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/alert(_:ispresented:actions:message:)-8dvt8`
+- `/documentation/swiftui/view/confirmationdialog(_:ispresented:titlevisibility:actions:message:)-43f72`
+- `/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)`
+
+---
+
+## Text Input
+
+**Search queries:**
+- `SwiftUI TextField onSubmit`
+- `SwiftUI textInputAutocapitalization`
+- `SwiftUI autocorrectionDisabled`
+- `SwiftUI focused modifier`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/onsubmit(of:_:)`
+- `/documentation/swiftui/view/textinputautocapitalization(_:)`
+- `/documentation/swiftui/view/autocorrectiondisabled(_:)`
+- `/documentation/swiftui/focusstate`
+
+---
+
+## Layout
+
+**Search queries:**
+- `SwiftUI ignoresSafeArea`
+- `SwiftUI containerRelativeFrame`
+- `SwiftUI visualEffect`
+- `SwiftUI GeometryReader`
+- `SwiftUI coordinateSpace`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/ignoressafearea(_:edges:)`
+- `/documentation/swiftui/view/containerrelativeframe(_:alignment:_:)`
+- `/documentation/swiftui/view/visualeffect(_:)`
+- `/documentation/swiftui/geometryreader`
+- `/documentation/swiftui/view/coordinatespace(_:)`
+
+---
+
+## Gestures
+
+**Search queries:**
+- `SwiftUI MagnifyGesture`
+- `SwiftUI RotateGesture`
+- `SwiftUI MagnificationGesture deprecated`
+- `SwiftUI RotationGesture deprecated`
+
+**Documentation paths:**
+- `/documentation/swiftui/magnifygesture`
+- `/documentation/swiftui/rotategesture`
+- `/documentation/swiftui/magnificationgesture`
+- `/documentation/swiftui/rotationgesture`
+
+---
+
+## Accessibility
+
+**Search queries:**
+- `SwiftUI accessibilityLabel`
+- `SwiftUI accessibility deprecated`
+- `SwiftUI accessibilityRepresentation`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/accessibilitylabel(_:)-1d7jv`
+- `/documentation/swiftui/view/accessibilityvalue(_:)-7a2ql`
+- `/documentation/swiftui/view/accessibilityhint(_:)`
+- `/documentation/swiftui/view/accessibilityrepresentation(representation:)`
+
+---
+
+## Animations
+
+**Search queries:**
+- `SwiftUI animation value deprecated`
+- `SwiftUI withAnimation`
+- `SwiftUI phaseAnimator`
+- `SwiftUI keyframeAnimator`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/animation(_:value:)`
+- `/documentation/swiftui/view/phaseanimator(_:content:animation:)`
+- `/documentation/swiftui/view/keyframeanimator(initialvalue:repeating:content:keyframes:)`
+
+---
+
+## Tabs
+
+**Search queries:**
+- `SwiftUI Tab API`
+- `SwiftUI tabItem deprecated`
+- `SwiftUI TabView`
+
+**Documentation paths:**
+- `/documentation/swiftui/tab`
+- `/documentation/swiftui/tabview`
+- `/documentation/swiftui/view/tabitem(_:)`
+
+---
+
+## Previews
+
+**Search queries:**
+- `SwiftUI Previewable`
+- `SwiftUI Preview macro`
+
+**Documentation paths:**
+- `/documentation/swiftui/previewable()`
+- `/documentation/swiftui/preview(_:body:)`
+
+---
+
+## Liquid Glass (iOS 26+)
+
+**Search queries:**
+- `SwiftUI glassEffect`
+- `SwiftUI GlassEffectContainer`
+- `SwiftUI glassProminent`
+- `SwiftUI backgroundExtensionEffect`
+
+**Documentation paths:**
+- `/documentation/swiftui/view/glasseffect(_:in:isenabled:)`
+- `/documentation/swiftui/glasseffectcontainer`
+- `/documentation/swiftui/view/backgroundextensioneffect()`
+- `/documentation/swiftui/view/scrolledgeeffectstyle(_:for:)`
+- `/documentation/swiftui/view/tabbarminimizebehavior(_:)`
+
+---
+
+## Scroll & Lists
+
+**Search queries:**
+- `SwiftUI ScrollViewReader`
+- `SwiftUI scrollPosition`
+- `SwiftUI scrollTargetBehavior`
+- `SwiftUI ForEach`
+
+**Documentation paths:**
+- `/documentation/swiftui/scrollviewreader`
+- `/documentation/swiftui/view/scrollposition(id:)`
+- `/documentation/swiftui/view/scrolltargetbehavior(_:)`
+- `/documentation/swiftui/foreach`
+
+---
+
+## WWDC Sessions
+
+Key "What's new in SwiftUI" sessions to check for API announcements:
+
+- `/videos/play/wwdc2024/10144` - What's new in SwiftUI (WWDC24)
+- `/videos/play/wwdc2024/10145` - SwiftUI essentials (WWDC24)
+- `/videos/play/wwdc2025/232` - What's new in SwiftUI (WWDC25)
+- `/videos/play/wwdc2023/10148` - What's new in SwiftUI (WWDC23)
+- `/videos/play/wwdc2022/10052` - What's new in SwiftUI (WWDC22)
+
+When a new WWDC occurs, add the latest "What's new in SwiftUI" session path here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,12 @@ When adding new content:
 
 If unsure, err on the side of excluding content. It's better to have a focused, factual skill than a comprehensive but opinionated one.
 
+## Maintenance Skills
+
+This repository includes a maintenance skill for keeping API guidance up to date:
+
+- **`.agents/skills/update-swiftui-apis/SKILL.md`** — Scan Apple's SwiftUI documentation via the Sosumi MCP, identify deprecated APIs and their modern replacements, and update `swiftui-expert-skill/references/latest-apis.md`. Use after new iOS/Xcode releases or when you want to refresh the deprecated API reference.
+
 ## Summary
 
 **Focus**: SwiftUI APIs, patterns, and correctness

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ If you use the `skill-creator` skill, you can:
 - Edit Markdown files directly
 - Ensure headings and checklists stay consistent
 
+## Updating Latest API Guidance
+
+To refresh the deprecated-to-modern API reference after a new iOS or Xcode release, use the maintenance skill at `.agents/skills/update-swiftui-apis/SKILL.md`. It walks through scanning Apple's documentation via the Sosumi MCP and updating `swiftui-expert-skill/references/latest-apis.md` with new findings.
+
 ## Types of Contributions
 - Fix incorrect SwiftUI guidance
 - Add new modern APIs or deprecations

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ swiftui-expert-skill/
 ```
 <!-- END REFERENCE STRUCTURE -->
 
+## Maintenance
+
+The repository includes a maintenance skill for keeping API guidance current:
+
+```text
+.agents/skills/update-swiftui-apis/
+  SKILL.md               - Workflow for scanning Apple docs and updating latest-apis.md
+  references/
+    scan-manifest.md     - Categorized API areas, doc paths, and search queries to scan
+```
+
+Use this skill after new iOS or Xcode releases to refresh the deprecated API reference. It requires the [Sosumi MCP](https://github.com/nicklama/sosumi) to be available. See `AGENTS.md` or `CONTRIBUTING.md` for details.
+
 ## Contributing
 
 Contributions are welcome! This repository follows the [Agent Skills open format](https://agentskills.io/home), which has specific structural requirements.


### PR DESCRIPTION
## Summary

- Adds a **cross-IDE maintenance skill** at `.agents/skills/update-swiftui-apis/` that codifies the workflow from PR #28 into a reusable agent skill
- Any contributor using Cursor, Claude Code, Codex, or GitHub Copilot can run this skill to scan Apple's documentation for deprecated SwiftUI APIs and update `latest-apis.md`
- Includes a **scan manifest** (`references/scan-manifest.md`) with categorized API areas, documentation paths, search queries, and WWDC session paths
- Updates `AGENTS.md`, `CONTRIBUTING.md`, and `README.md` to reference the new skill

## What this skill does

Uses the [Sosumi MCP](https://github.com/nicklama/sosumi) to systematically:
1. Search and fetch Apple developer documentation for SwiftUI API categories
2. Identify deprecated APIs and their modern replacements
3. Update `swiftui-expert-skill/references/latest-apis.md` in the established format
4. Open a PR with the changes

## Why `.agents/skills/` instead of `.cursor/skills/`

The `.agents/skills/` directory is tool-agnostic. Combined with the reference in `AGENTS.md`, the skill is discoverable by all major AI coding tools without IDE-specific configuration.

## Test plan

- [ ] Verify SKILL.md frontmatter is valid YAML with `name` and `description`
- [ ] Verify scan-manifest.md covers all categories from the existing `latest-apis.md`
- [ ] Verify AGENTS.md, CONTRIBUTING.md, and README.md references are correct
- [ ] Run the skill manually with Sosumi MCP enabled to confirm the workflow works end-to-end