### PR TITLE
Inform about decorative images

### DIFF
--- a/swiftui-expert-skill/references/accessibility-patterns.md
+++ b/swiftui-expert-skill/references/accessibility-patterns.md
@@ -56,7 +56,7 @@ Use `.disabled(true)` to make VoiceOver announce "Dimmed" for non-interactive el
 Use `Image(decorative:bundle:)` when an asset image is purely visual and should not appear in the accessibility tree.
 
 ```swift
-Image(decorative: "confetti", bundle: nil)
+Image(decorative: "confetti")
 ```
 
 This is appropriate for backgrounds, flourishes, and icons that do not add meaning beyond nearby text.


### PR DESCRIPTION
Hello guys,

### Summary
Adds SwiftUI accessibility guidance for decorative images to the expert skill reference.

### Changes

- add a new Decorative Images section to accessibility-patterns.md
- document when to use Image(decorative:bundle:) for purely visual asset images
- clarify that informative images should remain accessible and use a clear label
- note accessibilityHidden(true) as the alternative for decorative non-asset images such as SF Symbols
- update the accessibility checklist to include decorative-image handling

### Testing
- documentation change only
- no runtime tests required