### PR TITLE
Sharpen SKILL.md concision and add OpenAI manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,16 @@ To automatically provide this Skill to everyone working in a repository, configu
 
 When team members open the project, Claude Code will prompt them to install the Skill.
 
-### Option D: Manual install
+### Option D: Codex / OpenAI-compatible tools
+This repository includes an `agents/openai.yaml` manifest. Copy or symlink the `swiftui-expert-skill/` folder into your Codex skills directory:
+
+```bash
+cp -R swiftui-expert-skill/ "$CODEX_HOME/skills/swiftui-expert-skill"
+```
+
+See [Codex skills documentation](https://developers.openai.com/codex/skills/) for details on where to save skills.
+
+### Option E: Manual install
 1) **Clone** this repository.
 2) **Install or symlink** the `swiftui-expert-skill/` folder following your tool’s official skills installation docs (see links below).
 3) **Use your AI tool** as usual and ask it to use the “swiftui-expert” skill for SwiftUI tasks.

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,25 @@
+name: swiftui-expert
+version: "2.2.0"
+description: >-
+  Expert SwiftUI guidance for state management, view composition,
+  performance, and iOS 26+ Liquid Glass adoption.
+author:
+  name: Antoine van der Lee
+  email: contact@avanderlee.com
+repository: https://github.com/AvdLee/SwiftUI-Agent-Skill
+license: MIT
+logo: assets/logo.svg
+keywords:
+  - swift
+  - swiftui
+  - ios
+  - apple
+  - state-management
+  - performance
+  - liquid-glass
+  - view-composition
+  - navigation
+  - lists
+  - sheets
+skills:
+  - swiftui-expert-skill

--- a/swiftui-expert-skill/SKILL.md
+++ b/swiftui-expert-skill/SKILL.md
@@ -5,277 +5,98 @@ description: Write, review, or improve SwiftUI code following best practices for
 
 # SwiftUI Expert Skill
 
-## Overview
-Use this skill to build, review, or improve SwiftUI features with correct state management, optimal view composition, and iOS 26+ Liquid Glass styling. Prioritize native APIs, Apple design guidance, and performance-conscious patterns. This skill focuses on facts and best practices without enforcing specific architectural patterns.
+## Operating Rules
 
-## Workflow Decision Tree
+- Consult `references/latest-apis.md` at the start of every task to avoid deprecated APIs
+- Prefer native SwiftUI APIs over UIKit/AppKit bridging unless bridging is necessary
+- Focus on correctness and performance; do not enforce specific architectures (MVVM, VIPER, etc.)
+- Encourage separating business logic from views for testability without mandating how
+- Follow Apple's Human Interface Guidelines and API design patterns
+- Only adopt Liquid Glass when explicitly requested by the user (see `references/liquid-glass.md`)
+- Present performance optimizations as suggestions, not requirements
+- Use `#available` gating with sensible fallbacks for version-specific APIs
 
-### 1) Review existing SwiftUI code
-- **First, consult `references/latest-apis.md`** to ensure only current, non-deprecated APIs are used
-- Check property wrapper usage against the selection guide (see `references/state-management.md`)
-- Verify view composition follows extraction rules (see `references/view-structure.md`)
-- Check performance patterns are applied (see `references/performance-patterns.md`)
-- Verify list patterns use stable identity (see `references/list-patterns.md`)
-- Check animation patterns for correctness (see `references/animation-basics.md`, `references/animation-transitions.md`)
-- Review accessibility: proper grouping, traits, Dynamic Type support (see `references/accessibility-patterns.md`)
-- Check chart patterns for correct mark usage, stable data identity, and availability gating (see `references/charts.md`; for accessibility and fallback strategies see `references/charts-accessibility.md`)
-- For macOS targets: verify correct use of macOS-specific APIs and patterns (see `references/macos-scenes.md`, `references/macos-window-styling.md`, `references/macos-views.md`)
-- Inspect Liquid Glass usage for correctness and consistency (see `references/liquid-glass.md`)
-- Validate iOS 26+ availability handling with sensible fallbacks
+## Task Workflow
 
-### 2) Improve existing SwiftUI code
-- **First, consult `references/latest-apis.md`** to replace any deprecated APIs with their modern equivalents
-- Audit state management for correct wrapper selection (see `references/state-management.md`)
-- Extract complex views into separate subviews (see `references/view-structure.md`)
-- Refactor hot paths to minimize redundant state updates (see `references/performance-patterns.md`)
-- Ensure ForEach uses stable identity (see `references/list-patterns.md`)
-- Improve animation patterns (use value parameter, proper transitions, see `references/animation-basics.md`, `references/animation-transitions.md`)
-- Improve accessibility: use `Button` over tap gestures, add `@ScaledMetric` for Dynamic Type (see `references/accessibility-patterns.md`)
-- Review chart code for correct modifier scope, styling, and accessibility (see `references/charts.md`, `references/charts-accessibility.md`)
-- For macOS targets: adopt macOS-specific APIs (MenuBarExtra, Settings, Table, Commands, etc.) where appropriate (see `references/macos-scenes.md`, `references/macos-window-styling.md`, `references/macos-views.md`)
-- Suggest image downsampling when `UIImage(data:)` is used (as optional optimization, see `references/image-optimization.md`)
-- Adopt Liquid Glass only when explicitly requested by the user
+### Review existing SwiftUI code
+- Read the code under review and identify which topics apply
+- Flag deprecated APIs (compare against `references/latest-apis.md`)
+- Run the Topic Router below for each relevant topic
+- Validate `#available` gating and fallback paths for iOS 26+ features
 
-### 3) Implement new SwiftUI feature
-- **First, consult `references/latest-apis.md`** to use only current, non-deprecated APIs for the target deployment version
-- Design data flow first: identify owned vs injected state (see `references/state-management.md`)
-- Structure views for optimal diffing (extract subviews early, see `references/view-structure.md`)
-- Keep business logic in services and models for testability (see `references/layout-best-practices.md`)
-- Use correct animation patterns (implicit vs explicit, transitions, see `references/animation-basics.md`, `references/animation-transitions.md`, `references/animation-advanced.md`)
-- Use `Button` for tappable elements, add accessibility grouping and labels (see `references/accessibility-patterns.md`)
-- For charts: use correct mark types, stable data identity, and gate iOS 17+/18+/26+ APIs (see `references/charts.md`; for accessibility see `references/charts-accessibility.md`)
-- For macOS targets: use macOS-specific scenes (see `references/macos-scenes.md`), window styling (see `references/macos-window-styling.md`), and views like HSplitView, Table (see `references/macos-views.md`)
-- Apply glass effects after layout/appearance modifiers (see `references/liquid-glass.md`)
-- Gate iOS 26+ features with `#available` and provide fallbacks
+### Improve existing SwiftUI code
+- Audit current implementation against the Topic Router topics
+- Replace deprecated APIs with modern equivalents from `references/latest-apis.md`
+- Refactor hot paths to reduce unnecessary state updates
+- Extract complex view bodies into separate subviews
+- Suggest image downsampling when `UIImage(data:)` is encountered (optional optimization, see `references/image-optimization.md`)
 
-## Core Guidelines
+### Implement new SwiftUI feature
+- Design data flow first: identify owned vs injected state
+- Structure views for optimal diffing (extract subviews early)
+- Apply correct animation patterns (implicit vs explicit, transitions)
+- Use `Button` for all tappable elements; add accessibility grouping and labels
+- Gate version-specific APIs with `#available` and provide fallbacks
 
-### State Management
-- `@State` must be `private`; use for internal view state
-- `@Binding` only when a child needs to **modify** parent state
-- `@StateObject` when view **creates** the object; `@ObservedObject` when **injected**
-- iOS 17+: Use `@State` with `@Observable` classes; use `@Bindable` for injected observables needing bindings
-- Use `let` for read-only values; `var` + `.onChange()` for reactive reads
-- Never pass values into `@State` or `@StateObject` — they only accept initial values
-- Nested `ObservableObject` doesn't propagate changes — pass nested objects directly; `@Observable` handles nesting fine
+### Topic Router
 
-### View Composition
-- Extract complex views into separate subviews for better readability and performance
-- Prefer modifiers over conditional views for state changes (maintains view identity)
-- Keep view `body` simple and pure (no side effects or complex logic)
-- Use `@ViewBuilder` functions only for small, simple sections
-- Prefer `@ViewBuilder let content: Content` over closure-based content properties
-- Keep business logic in services and models; views should orchestrate UI flow
-- Action handlers should reference methods, not contain inline logic
-- Views should work in any context (don't assume screen size or presentation style)
+Consult the reference file for each topic relevant to the current task:
 
-### Performance
-- Pass only needed values to views (avoid large "config" or "context" objects)
-- Eliminate unnecessary dependencies to reduce update fan-out
-- Consider per-item `@Observable` state objects in lists to narrow update/dependency scope
-- Consider whether frequently-changing values belong in the environment; prefer more local state when it reduces unnecessary view updates
-- Check for value changes before assigning state in hot paths
-- Avoid redundant state updates in `onReceive`, `onChange`, scroll handlers
-- Minimize work in frequently executed code paths
-- Use `LazyVStack`/`LazyHStack` for large lists
-- Use stable identity for `ForEach` (never `.indices` for dynamic content)
-- Ensure constant number of views per `ForEach` element
-- Avoid inline filtering in `ForEach` (prefilter and cache)
-- Avoid `AnyView` in list rows
-- Consider POD views for fast diffing (or wrap expensive views in POD parents)
-- Suggest image downsampling when `UIImage(data:)` is encountered (as optional optimization)
-- Avoid layout thrash (deep hierarchies, excessive `GeometryReader`)
-- Gate frequent geometry updates by thresholds
-- Use `Self._logChanges()` or `Self._printChanges()` to debug unexpected view updates
-- `Shape.path()`, `visualEffect`, `Layout`, and `onGeometryChange` closures may run off the main thread — capture values instead of accessing `@MainActor` state
+| Topic | Reference |
+|-------|-----------|
+| State management | `references/state-management.md` |
+| View composition | `references/view-structure.md` |
+| Performance | `references/performance-patterns.md` |
+| Lists and ForEach | `references/list-patterns.md` |
+| Layout | `references/layout-best-practices.md` |
+| Sheets and navigation | `references/sheet-navigation-patterns.md` |
+| ScrollView | `references/scroll-patterns.md` |
+| Animations (basics) | `references/animation-basics.md` |
+| Animations (transitions) | `references/animation-transitions.md` |
+| Animations (advanced) | `references/animation-advanced.md` |
+| Accessibility | `references/accessibility-patterns.md` |
+| Swift Charts | `references/charts.md` |
+| Charts accessibility | `references/charts-accessibility.md` |
+| Image optimization | `references/image-optimization.md` |
+| Liquid Glass (iOS 26+) | `references/liquid-glass.md` |
+| macOS scenes | `references/macos-scenes.md` |
+| macOS window styling | `references/macos-window-styling.md` |
+| macOS views | `references/macos-views.md` |
+| Deprecated API lookup | `references/latest-apis.md` |
 
-### Animations
-- Use `.animation(_:value:)` with value parameter (deprecated version without value is too broad)
-- Use `withAnimation` for event-driven animations (button taps, gestures)
-- Prefer transforms (`offset`, `scale`, `rotation`) over layout changes (`frame`) for performance
-- Transitions require animations outside the conditional structure
-- Custom `Animatable` implementations must have explicit `animatableData` (or use `@Animatable` macro on iOS 26+)
-- iOS 26+: Use `@Animatable` macro to auto-synthesize `animatableData`; use `@AnimatableIgnored` to exclude properties
-- Use `.phaseAnimator` for multi-step sequences (iOS 17+)
-- Use `.keyframeAnimator` for precise timing control (iOS 17+)
-- Animation completion handlers need `.transaction(value:)` for reexecution
-- Implicit animations override explicit animations (later in view tree wins)
+## Correctness Checklist
 
-### Accessibility
-- Prefer `Button` over `onTapGesture` for tappable elements (free VoiceOver support)
-- Use `@ScaledMetric` for custom numeric values that should scale with Dynamic Type
-- Group related elements with `accessibilityElement(children: .combine)` for joined labels
-- Provide `accessibilityLabel` when default labels are unclear or missing
-- Use `accessibilityRepresentation` for custom controls that should behave like native ones
+These are hard rules -- violations are always bugs:
 
-### Liquid Glass (iOS 26+)
-**Only adopt when explicitly requested by the user.**
-- Use native `glassEffect`, `GlassEffectContainer`, and glass button styles
-- Wrap multiple glass elements in `GlassEffectContainer`
-- Apply `.glassEffect()` after layout and visual modifiers
-- Use `.interactive()` only for tappable/focusable elements
-- Use `glassEffectID` with `@Namespace` for morphing transitions
-
-## Quick Reference
-
-### Property Wrapper Selection
-| Wrapper | Use When |
-|---------|----------|
-| `@State` | Internal view state (must be `private`) |
-| `@Binding` | Child modifies parent's state |
-| `@StateObject` | View owns an `ObservableObject` |
-| `@ObservedObject` | View receives an `ObservableObject` |
-| `@Bindable` | iOS 17+: Injected `@Observable` needing bindings |
-| `let` | Read-only value from parent |
-| `var` | Read-only value watched via `.onChange()` |
-
-### Liquid Glass Patterns
-```swift
-// Basic glass effect with fallback
-if #available(iOS 26, *) {
-    content
-        .padding()
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 16))
-} else {
-    content
-        .padding()
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
-}
-
-// Grouped glass elements
-GlassEffectContainer(spacing: 24) {
-    HStack(spacing: 24) {
-        GlassButton1()
-        GlassButton2()
-    }
-}
-
-// Glass buttons
-Button("Confirm") { }
-    .buttonStyle(.glassProminent)
-```
-
-## Review Checklist
-
-### Latest APIs (see `references/latest-apis.md`)
-- [ ] No deprecated modifiers used (check against the quick lookup table)
-- [ ] API choices match the project's minimum deployment target
-
-### State Management
 - [ ] `@State` properties are `private`
-- [ ] `@Binding` only where child modifies parent state
-- [ ] `@StateObject` for owned, `@ObservedObject` for injected
-- [ ] iOS 17+: `@State` with `@Observable`, `@Bindable` for injected
-- [ ] Passed values NOT declared as `@State` or `@StateObject`
-- [ ] Nested `ObservableObject` avoided (or passed directly to child views)
-
-### Sheets & Navigation (see `references/sheet-navigation-patterns.md`)
-- [ ] Using `.sheet(item:)` for model-based sheets
-- [ ] Sheets own their actions and dismiss internally
-
-### ScrollView (see `references/scroll-patterns.md`)
-- [ ] Using `ScrollViewReader` with stable IDs for programmatic scrolling
-
-### View Structure (see `references/view-structure.md`)
-- [ ] Using modifiers instead of conditionals for state changes
-- [ ] Complex views extracted to separate subviews
-- [ ] Container views use `@ViewBuilder let content: Content`
-- [ ] `.compositingGroup()` before `.clipShape()` on layered views
-
-### Performance (see `references/performance-patterns.md`)
-- [ ] View `body` kept simple and pure (no side effects)
-- [ ] Passing only needed values (not large config objects)
-- [ ] Eliminating unnecessary dependencies
-- [ ] Consider making @Observable dependencies as granular as needed (for example, per-item data for list rows) when it helps performance
-- [ ] State updates check for value changes before assigning
-- [ ] Hot paths minimize state updates
-- [ ] No object creation in `body`
-- [ ] Heavy computation moved out of `body`
-- [ ] Sendable closures capture values instead of accessing @MainActor state
-
-### List Patterns (see `references/list-patterns.md`)
-- [ ] ForEach uses stable identity (not `.indices`)
-- [ ] Constant number of views per ForEach element
-- [ ] No inline filtering in ForEach
-- [ ] No `AnyView` in list rows
-
-### Layout (see `references/layout-best-practices.md`)
-- [ ] Avoiding layout thrash (deep hierarchies, excessive GeometryReader)
-- [ ] Gating frequent geometry updates by thresholds
-- [ ] Business logic kept in services and models (not in views)
-- [ ] Action handlers reference methods (not inline logic)
-- [ ] Using relative layout (not hard-coded constants)
-- [ ] Views work in any context (context-agnostic)
-
-### Animations (see `references/animation-basics.md`, `references/animation-transitions.md`, `references/animation-advanced.md`)
-- [ ] Using `.animation(_:value:)` with value parameter
-- [ ] Using `withAnimation` for event-driven animations
-- [ ] Transitions paired with animations outside conditional structure
-- [ ] Custom `Animatable` has explicit `animatableData` (or `@Animatable` macro on iOS 26+)
-- [ ] Preferring transforms over layout changes for animation performance
-- [ ] Phase animations for multi-step sequences (iOS 17+)
-- [ ] Keyframe animations for precise timing (iOS 17+)
-- [ ] Completion handlers use `.transaction(value:)` for reexecution
-
-### Accessibility (see `references/accessibility-patterns.md`)
-- [ ] `Button` used instead of `onTapGesture` for tappable elements
-- [ ] `@ScaledMetric` used for custom values that should scale with Dynamic Type
-- [ ] Related elements grouped with `accessibilityElement(children:)`
-- [ ] Custom controls use `accessibilityRepresentation` when appropriate
-
-### Charts (see `references/charts.md`, `references/charts-accessibility.md`)
-- [ ] `import Charts` is present in files using chart types
-- [ ] Chart data models use `Identifiable` (or explicit `id:` key path)
-- [ ] Chart-wide modifiers applied to `Chart`, not individual marks
-- [ ] iOS 17+ APIs (`SectorMark`, selection, scrollable axes) are availability-gated
-- [ ] iOS 18+ APIs (plot types like `LinePlot`, `AreaPlot`) are availability-gated
-- [ ] iOS 26+ APIs (`Chart3D`, `SurfacePlot`) are availability-gated
-- [ ] Meaningful `.value()` labels used for axes and accessibility
-- [ ] `foregroundStyle(by:)` used for categorical series (not manual per-mark colors)
-
-### macOS APIs (see `references/macos-scenes.md`, `references/macos-window-styling.md`, `references/macos-views.md`)
-- [ ] Using `Settings` scene for preferences (not a custom window)
-- [ ] Using `MenuBarExtra` for menu bar items (not AppKit `NSStatusItem`)
-- [ ] Using `Commands` / `CommandGroup` / `CommandMenu` for menu bar menus
-- [ ] `Table` adapts for compact size classes on iOS (first column shows combined info)
-- [ ] Window sizing configured with `defaultSize`, `windowResizability`, and `frame(minWidth:minHeight:)`
-- [ ] macOS-only code wrapped in `#if os(macOS)` conditionals
-- [ ] Using `NSViewRepresentable` with proper `makeNSView`/`updateNSView` lifecycle
-- [ ] Using `NavigationSplitView` (not `HSplitView`) for sidebar-based navigation
-- [ ] `HSplitView`/`VSplitView` reserved for IDE-style equal peer panes
-
-### Liquid Glass (iOS 26+)
-- [ ] `#available(iOS 26, *)` with fallback for Liquid Glass
-- [ ] Multiple glass views wrapped in `GlassEffectContainer`
-- [ ] `.glassEffect()` applied after layout/appearance modifiers
-- [ ] `.interactive()` only on user-interactable elements
-- [ ] Shapes and tints consistent across related elements
+- [ ] `@Binding` only where a child modifies parent state
+- [ ] Passed values never declared as `@State` or `@StateObject` (they ignore updates)
+- [ ] `@StateObject` for view-owned objects; `@ObservedObject` for injected
+- [ ] iOS 17+: `@State` with `@Observable`; `@Bindable` for injected observables needing bindings
+- [ ] `ForEach` uses stable identity (never `.indices` for dynamic content)
+- [ ] Constant number of views per `ForEach` element
+- [ ] `.animation(_:value:)` always includes the `value` parameter
+- [ ] iOS 26+ APIs gated with `#available` and fallback provided
+- [ ] `import Charts` present in files using chart types
 
 ## References
-- `references/latest-apis.md` - **Required reading for all workflows.** Version-segmented guide of deprecated-to-modern API transitions (iOS 15+ through iOS 26+)
-- `references/state-management.md` - Property wrappers and data flow
-- `references/view-structure.md` - View composition, extraction, and container patterns
-- `references/performance-patterns.md` - Performance optimization techniques and anti-patterns
-- `references/list-patterns.md` - ForEach identity, stability, Table (iOS 16+), and list best practices
-- `references/layout-best-practices.md` - Layout patterns, context-agnostic views, and testability
-- `references/accessibility-patterns.md` - Accessibility traits, grouping, Dynamic Type, and VoiceOver
-- `references/animation-basics.md` - Core animation concepts, implicit/explicit animations, timing, performance
-- `references/animation-transitions.md` - Transitions, custom transitions, Animatable protocol
-- `references/animation-advanced.md` - Transactions, phase/keyframe animations (iOS 17+), completion handlers (iOS 17+), `@Animatable` macro (iOS 26+)
-- `references/charts.md` - Swift Charts marks, axes, selection, styling, composition, and Chart3D (iOS 26+)
-- `references/charts-accessibility.md` - Charts accessibility (VoiceOver, Audio Graph, AXChartDescriptorRepresentable), fallback strategies, and WWDC sessions
-- `references/sheet-navigation-patterns.md` - Sheet presentation, NavigationSplitView, Inspector, and navigation patterns
-- `references/scroll-patterns.md` - ScrollView patterns and programmatic scrolling
-- `references/image-optimization.md` - AsyncImage, image downsampling, and optimization
-- `references/liquid-glass.md` - iOS 26+ Liquid Glass API
-- `references/macos-scenes.md` - macOS scene types: Settings, MenuBarExtra, WindowGroup, Window, UtilityWindow, DocumentGroup
-- `references/macos-window-styling.md` - macOS window configuration: toolbar styles, sizing, positioning, NavigationSplitView, Inspector, Commands
-- `references/macos-views.md` - macOS views and components: HSplitView, VSplitView, Table, PasteButton, file dialogs, drag & drop, AppKit interop
 
-## Philosophy
-
-This skill focuses on **facts and best practices**, not architectural opinions:
-- We don't enforce specific architectures (e.g., MVVM, VIPER)
-- We do encourage separating business logic for testability
-- We optimize for performance and maintainability
-- We follow Apple's Human Interface Guidelines and API design patterns
+- `references/latest-apis.md` -- **Read first for every task.** Deprecated-to-modern API transitions (iOS 15+ through iOS 26+)
+- `references/state-management.md` -- Property wrappers, data flow, `@Observable` migration
+- `references/view-structure.md` -- View extraction, container patterns, `@ViewBuilder`
+- `references/performance-patterns.md` -- Hot-path optimization, update control, `_logChanges()`
+- `references/list-patterns.md` -- ForEach identity, Table (iOS 16+), inline filtering pitfalls
+- `references/layout-best-practices.md` -- Layout patterns, GeometryReader alternatives
+- `references/accessibility-patterns.md` -- VoiceOver, Dynamic Type, grouping, traits
+- `references/animation-basics.md` -- Implicit/explicit animations, timing, performance
+- `references/animation-transitions.md` -- View transitions, `matchedGeometryEffect`, `Animatable`
+- `references/animation-advanced.md` -- Phase/keyframe animations (iOS 17+), `@Animatable` macro (iOS 26+)
+- `references/charts.md` -- Swift Charts marks, axes, selection, styling, Chart3D (iOS 26+)
+- `references/charts-accessibility.md` -- Charts VoiceOver, Audio Graph, fallback strategies
+- `references/sheet-navigation-patterns.md` -- Sheets, NavigationSplitView, Inspector
+- `references/scroll-patterns.md` -- ScrollViewReader, programmatic scrolling
+- `references/image-optimization.md` -- AsyncImage, downsampling, caching
+- `references/liquid-glass.md` -- iOS 26+ Liquid Glass effects and fallback patterns
+- `references/macos-scenes.md` -- Settings, MenuBarExtra, WindowGroup, multi-window
+- `references/macos-window-styling.md` -- Toolbar styles, window sizing, Commands
+- `references/macos-views.md` -- HSplitView, Table, PasteButton, AppKit interop

--- a/swiftui-expert-skill/references/liquid-glass.md
+++ b/swiftui-expert-skill/references/liquid-glass.md
@@ -19,6 +19,8 @@
 
 Liquid Glass is Apple's new design language introduced in iOS 26. It provides translucent, dynamic surfaces that respond to content and user interaction. This reference covers the native SwiftUI APIs for implementing Liquid Glass effects.
 
+**Only adopt Liquid Glass when explicitly requested by the user.** Do not proactively convert existing UI to glass effects.
+
 ## Availability
 
 All Liquid Glass APIs require iOS 26 or later. Always provide fallbacks:


### PR DESCRIPTION
## Summary

- **Refactored `swiftui-expert-skill/SKILL.md`** from 282 to 102 lines (~64% reduction) by removing sections that duplicated content already in the reference files (Core Guidelines, Quick Reference, Review Checklist, Philosophy). Replaced with a lean imperative operating guide: Operating Rules, Task Workflow with shared Topic Router, and a compact correctness-only checklist.
- **Migrated the Liquid Glass guardrail** ("only adopt when explicitly requested") into `references/liquid-glass.md` so it survives independently of the main skill file.
- **Added `agents/openai.yaml`** for Codex/OpenAI-compatible tooling, aligned with existing `.cursor-plugin/` and `.claude-plugin/` metadata.
- **Updated README** with a new "Option D: Codex / OpenAI-compatible tools" install section.

Addresses external review feedback on concision/context discipline (7.5/10) and packaging/completeness (7/10).

## Test plan

- [ ] Verify the new SKILL.md reads as an imperative workflow, not a reference handbook
- [ ] Confirm all 19 reference files are still correctly linked in the Topic Router and References sections
- [ ] Verify `agents/openai.yaml` metadata matches `.cursor-plugin/plugin.json` and `.claude-plugin/plugin.json`
- [ ] Check that the Liquid Glass guardrail appears in both the Operating Rules and `references/liquid-glass.md`
- [ ] Ensure README install options are sequential (A through E) and none are broken