### PR TITLE
Text Dynamic Type clarification and ScaledMetric example extend

### DIFF
--- a/swiftui-expert-skill/references/accessibility-patterns.md
+++ b/swiftui-expert-skill/references/accessibility-patterns.md
@@ -69,7 +69,7 @@ struct StatusRow: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
-                .frame(width: iconSize, height: iconSize)
+                .font(.system(size: iconSize))
             Text("Synced")
                 .font(.custom("AvenirNext-Regular", size: 17, relativeTo: .body))
         }


### PR DESCRIPTION
## Summary

Improve the accessibility reference with more complete guidance for Dynamic Type in SwiftUI since original info uses it without clarification.

## Changes

- Rename the Dynamic Type section to cover both text scaling and `@ScaledMetric`
- Add built-in SwiftUI text style examples for Dynamic Type-aware text
- Document Dynamic Type-aware custom fonts with `Font.custom(_:size:)` and `Font.custom(_:size:relativeTo:)`
- Expand `@ScaledMetric` guidance to cover non-text values like spacing, icons, and image sizes
- Add a checklist item for using built-in text styles or Dynamic Type-aware custom fonts

## Testing

- Not run
- Documentation-only change