### PR TITLE
feat: Add instructions for dynamic rows in a Table

### DIFF
--- a/swiftui-expert-skill/references/list-patterns.md
+++ b/swiftui-expert-skill/references/list-patterns.md
@@ -356,7 +356,7 @@ struct TipTable: View {
 }
 ```
 
-### Table with Dynamic Number of Rows
+### Table with Dynamic Number of Columns
 
 > **Availability:** iOS 17.4+, iPadOS 17.4+, Mac Catalyst 17.4+, macOS 14.4+, visionOS 1.1+
 
@@ -373,13 +373,15 @@ struct AudioChannel: Identifiable {
 struct AudioSample: Identifiable {
     let id: UUID
     let timestamp: TimeInterval
-    func level(channel: AudioChannel.ID) -> Double
+    func level(channel: AudioChannel.ID) -> Double {
+        1
+    }
 }
 
 @Observable
 class AudioSampleTrack {
     let channels: [AudioChannel]
-    var samples: some RandomAccessCollection<AudioSample> { get }
+    var samples: [AudioSample]
 }
 
 struct ContentView: View {


### PR DESCRIPTION
# Summary 

This PR adds instructions about dynamic row usage in Table views by utilising [`TableColumnForEach`](https://developer.apple.com/documentation/swiftui/tablecolumnforeach)

# Changes 
Added a section in `list-patterns.md` which explains the usage of `TableColumnForEach`

# Why this change? 
This closes a gap for implementations of `Table` where the number of rows is not known at compile time. It should prevent agents to come up with solutions that limit the number of columns with arbitrary numbers. 