### PR TITLE
Add Text(verbatim: ) Reference

### DIFF
--- a/swiftui-expert-skill/SKILL.md
+++ b/swiftui-expert-skill/SKILL.md
@@ -62,6 +62,7 @@ Consult the reference file for each topic relevant to the current task:
 | macOS scenes | `references/macos-scenes.md` |
 | macOS window styling | `references/macos-window-styling.md` |
 | macOS views | `references/macos-views.md` |
+| Text patterns | `references/text-patterns.md` |
 | Deprecated API lookup | `references/latest-apis.md` |
 
 ## Correctness Checklist
@@ -100,3 +101,4 @@ These are hard rules -- violations are always bugs:
 - `references/macos-scenes.md` -- Settings, MenuBarExtra, WindowGroup, multi-window
 - `references/macos-window-styling.md` -- Toolbar styles, window sizing, Commands
 - `references/macos-views.md` -- HSplitView, Table, PasteButton, AppKit interop
+- `references/text-patterns.md` -- Text initializer selection, verbatim vs localized

--- a/swiftui-expert-skill/references/text-patterns.md
+++ b/swiftui-expert-skill/references/text-patterns.md
@@ -9,7 +9,7 @@
 **Default: always use `Text("…")`.** Only use `Text(verbatim:)` when explicitly required for a string literal that must not be localized.
 
 ```swift
-// Localized literal - "Save" is used as the localization key and looked up in Localizable.strings
+// Localized literal - "Save" is used as the localization key and looked up in Localizable.strings (only if one exists in the project)
 Text("Save")
 
 // String variable - bypasses localization automatically; no verbatim needed

--- a/swiftui-expert-skill/references/text-patterns.md
+++ b/swiftui-expert-skill/references/text-patterns.md
@@ -1,0 +1,17 @@
+# SwiftUI Text Patterns Reference
+
+## Table of Contents
+
+- [Text Initialization: Verbatim vs Localized](#text-initialization-verbatim-vs-localized)
+
+## Text Initialization: Verbatim vs Localized
+
+Use the correct initializer based on whether the string should be localized.
+
+```swift
+// Localized - "Save" becomes the localization key, auto-exported to Localizable.strings
+Text("Save")
+
+// Non-localized - always displays "pencil", regardless of locale
+Text(verbatim: "pencil")
+```

--- a/swiftui-expert-skill/references/text-patterns.md
+++ b/swiftui-expert-skill/references/text-patterns.md
@@ -6,12 +6,27 @@
 
 ## Text Initialization: Verbatim vs Localized
 
-Use the correct initializer based on whether the string should be localized.
+**Default: always use `Text("…")`.** Only use `Text(verbatim:)` when explicitly required for a string literal that must not be localized.
 
 ```swift
-// Localized - "Save" becomes the localization key, auto-exported to Localizable.strings
+// Localized literal - "Save" is used as the localization key and looked up in Localizable.strings
 Text("Save")
 
-// Non-localized - always displays "pencil", regardless of locale
+// String variable - bypasses localization automatically; no verbatim needed
+let filename: String = model.exportFilename
+Text(filename)
+
+// Non-localized literal - use verbatim only when the literal must not be localized
 Text(verbatim: "pencil")
+```
+
+### Decision Flow
+
+```
+Is the input a String variable or dynamic value?
+└─ YES → Text(variable)          // bypasses localization automatically
+
+Is the string literal intended for localization?
+├─ YES → Text("…")               // default; key looked up in Localizable.strings
+└─ NO  → Text(verbatim: "…")     // only when explicitly non-localized
 ```


### PR DESCRIPTION
Hello,

Thank you for this amazing repo — it's a really valuable resource for the SwiftUI community.

This might seem like a small addition, but it's actually important for localized projects. When you use `Text("...")`, Xcode auto-exports it to `Localizable.strings`. Using it incorrectly for non-localized strings generates useless keys and empty arguments in the table.

### Summary
* Add `text-patterns.md` reference for rules specific to `Text` view
* Covering `Text` initializer selection (`Text("…")` vs `Text(verbatim:)`) in the new file
* Register the new file in `SKILL.md` so agents route to it automatically