### PR TITLE
Shorten skill description

### DIFF
--- a/swiftui-expert-skill/SKILL.md
+++ b/swiftui-expert-skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: swiftui-expert-skill
-description: Write, review, or improve SwiftUI code following best practices for state management, view composition, performance, macOS-specific APIs, and iOS 26+ Liquid Glass adoption. Use when building new SwiftUI features, refactoring existing views, reviewing code quality, or adopting modern SwiftUI patterns. Also triggers whenever an Xcode Instruments `.trace` file is referenced (to analyse it) or the user asks to **record** a new trace — attach to a running app, launch one fresh, or capture a manually-stopped session with the bundled `record_trace.py`. A target SwiftUI source file is optional; if provided it grounds recommendations in specific lines, but a trace alone is enough to diagnose hangs, hitches, CPU hotspots, and high-severity SwiftUI updates.
+description: Use when writing, reviewing, or refactoring SwiftUI code for iOS or macOS, including state management, view composition, performance, Liquid Glass adoption, or Instruments `.trace` capture/analysis for hangs, hitches, CPU hotspots, or
+  excessive view updates.
 ---
 
 # SwiftUI Expert Skill


### PR DESCRIPTION
Since skill descriptions are a part of the context, codex CLI warns about  truncated skill descriptions.

```
⚠ Warning: Exceeded skills context budget of 2%. Loaded skill descriptions were truncated by an average of 219 characters per skill.
```

This PR shortens the skill description from 756 characters to 258 characters.