### PR TITLE
fix: correct two compile errors in liquid-glass.md — Glass.prominent and GlassEffectStyle

### DIFF
--- a/swiftui-expert-skill/references/liquid-glass.md
+++ b/swiftui-expert-skill/references/liquid-glass.md
@@ -40,7 +40,7 @@ if #available(iOS 26, *) {
 The primary modifier for applying glass effects to views:
 
 ```swift
-.glassEffect(_ style: GlassEffectStyle = .regular, in shape: some Shape = .rect)
+.glassEffect(_ glass: Glass = .regular, in shape: some Shape = .rect, isEnabled: Bool = true)
 ```
 
 #### Basic Usage
@@ -68,7 +68,7 @@ Text("Capsule")
     .glassEffect(in: .capsule)
 ```
 
-### GlassEffectStyle
+### Glass
 
 #### Available Styles
 
@@ -360,12 +360,12 @@ if #available(iOS 26, *) {
 extension View {
     @ViewBuilder
     func glassEffectWithFallback(
-        _ style: GlassEffectStyle = .regular,
+        _ glass: Glass = .regular,
         in shape: some Shape = .rect,
         fallbackMaterial: Material = .ultraThinMaterial
     ) -> some View {
         if #available(iOS 26, *) {
-            self.glassEffect(style, in: shape)
+            self.glassEffect(glass, in: shape)
         } else {
             self.background(fallbackMaterial, in: shape)
         }

--- a/swiftui-expert-skill/references/liquid-glass.md
+++ b/swiftui-expert-skill/references/liquid-glass.md
@@ -70,12 +70,17 @@ Text("Capsule")
 
 ### GlassEffectStyle
 
-#### Prominence Levels
+#### Available Styles
+
+The `Glass` type exposes three static values — there is no `.prominent`:
 
 ```swift
-.glassEffect(.regular)     // Standard glass appearance
-.glassEffect(.prominent)   // More visible, higher contrast
+.glassEffect(.regular)   // Standard glass appearance (most common)
+.glassEffect(.clear)     // Nearly invisible glass surface
+.glassEffect(.identity)  // No-op / pass-through glass
 ```
+
+To make a surface appear more prominent, increase the tint opacity instead of reaching for a non-existent `.prominent` property.
 
 #### Tinting
 
@@ -83,7 +88,7 @@ Add color tint to the glass:
 
 ```swift
 .glassEffect(.regular.tint(.blue))
-.glassEffect(.prominent.tint(.red.opacity(0.3)))
+.glassEffect(.regular.tint(.red.opacity(0.3)))
 ```
 
 #### Interactivity
@@ -307,7 +312,9 @@ struct GlassSegmentedControl: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
                         .glassEffect(
-                            selection == index ? .prominent.interactive() : .regular.interactive(),
+                            selection == index
+                                ? .regular.tint(.accentColor.opacity(0.4)).interactive()
+                                : .regular.interactive(),
                             in: .capsule
                         )
                         .glassEffectID(selection == index ? "selected" : "option\(index)", in: animation)
@@ -413,4 +420,4 @@ An automatic scroll edge effect blurs and fades content under system toolbars to
 - [ ] `glassEffectID` with `@Namespace` for morphing
 - [ ] Consistent shapes and spacing across feature
 - [ ] Container spacing matches layout spacing
-- [ ] Appropriate prominence levels used
+- [ ] Tint opacity used instead of non-existent `.prominent` for emphasis


### PR DESCRIPTION
Fixes #64.

## What was wrong

The skill file had two categories of incorrect API references that would cause agent-generated code to fail to compile.

### 1. `Glass.prominent` does not exist

The file used `.prominent` as a `Glass` material style in several places. This property is not part of the shipping SDK on **any** platform (iOS 26, macOS 26, tvOS 26, watchOS 26) — confirmed against the `SwiftUICore.swiftinterface` files from both the macOS 26 and iOS 26 SDKs, and Apple's official documentation JSON.

The confusion likely came from mixing up two separate APIs:
- `Glass` material styles: `.regular`, `.clear`, `.identity` — these are the only three
- `ButtonStyle` variants: `.buttonStyle(.glass)` and `.buttonStyle(.glassProminent)` — these are real and unrelated

There is no "prominence level" on the `Glass` material. To make a glass surface appear more visually prominent, the correct approach is a stronger tint opacity.

### 2. `GlassEffectStyle` is not a type

The modifier signature and a helper function used `GlassEffectStyle` as the parameter type. The actual type is `Glass`. The parameter label was also wrong (`style` → `glass`) and the `isEnabled: Bool = true` parameter was missing from the signature entirely. The `isEnabled` parameter is confirmed by its presence in the official selector `glassEffect(_:in:isEnabled:)`, which Apple's own developer forums surface in a visionOS error message.

## What changed

**Commit 1 — Glass.prominent**
- "Prominence Levels" section renamed to "Available Styles"; documents all three real `Glass` statics with descriptions
- Added a note that tint opacity (not a non-existent prominence enum) is the right way to increase emphasis
- Tinting example: `.prominent.tint(...)` → `.regular.tint(...)`
- Segmented control example: selected-state `.prominent.interactive()` → `.regular.tint(.accentColor.opacity(0.4)).interactive()`
- Checklist item reworded away from "prominence levels"

**Commit 2 — GlassEffectStyle**
- Modifier signature: `GlassEffectStyle` → `Glass`, `style` → `glass`, added `isEnabled: Bool = true`
- Section heading: `### GlassEffectStyle` → `### Glass`
- `glassEffectWithFallback` helper: parameter type and internal reference updated to `Glass`

## What was not changed

The `.buttonStyle(.glass)` and `.buttonStyle(.glassProminent)` examples are correct and untouched.

## Test plan

- [ ] Paste any snippet from the updated "Available Styles" section into an iOS 26 / macOS 26 target — all compile without error
- [ ] `glassEffectWithFallback` compiles against iOS 26 SDK
- [ ] `.buttonStyle(.glass)` and `.buttonStyle(.glassProminent)` examples (unchanged) still compile