### PR TITLE
Merge learnings from Apple's Xcode 27 swiftui-specialist skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,19 @@ swiftui-expert-skill/
     layout-best-practices.md - Layout patterns and GeometryReader alternatives
     liquid-glass.md - iOS 26+ glass effects and fallback patterns
     list-patterns.md - ForEach identity and list performance
+    localization.md
     macos-scenes.md - Scene lifecycle, multi-window setups, and menu bar scenes on macOS
     macos-views.md - macOS-specific SwiftUI views and platform differences from iOS
     macos-window-styling.md - Window chrome, toolbar, and title bar styling in SwiftUI
     performance-patterns.md - Hot-path optimizations and update control
+    previews.md
     scroll-patterns.md - ScrollViewReader and programmatic scrolling
     sheet-navigation-patterns.md - Sheets and type-safe navigation
+    soft-deprecation.md
     state-management.md - Property wrapper selection and data flow
+    text-patterns.md
+    trace-analysis.md
+    trace-recording.md
     view-structure.md - View extraction and composition patterns
 ```
 <!-- END REFERENCE STRUCTURE -->

--- a/swiftui-expert-skill/SKILL.md
+++ b/swiftui-expert-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-expert-skill
-description: Use when writing, reviewing, or refactoring SwiftUI code for iOS or macOS, including state management, view composition, performance, Liquid Glass adoption, or Instruments `.trace` capture/analysis for hangs, hitches, CPU hotspots, or
+description: Use when writing, reviewing, or refactoring SwiftUI code for iOS or macOS, including state management and `@Observable` data flow, view composition and invalidation/performance, lists and `ForEach` identity, environment usage, localization, animations, Liquid Glass adoption, migrating soft-deprecated APIs, or Instruments `.trace` capture/analysis for hangs, hitches, CPU hotspots, or
   excessive view updates.
 ---
 
@@ -114,7 +114,9 @@ Consult the reference file for each topic relevant to the current task:
 | macOS window styling | `references/macos-window-styling.md` |
 | macOS views | `references/macos-views.md` |
 | Text patterns | `references/text-patterns.md` |
+| Localization | `references/localization.md` |
 | Deprecated API lookup | `references/latest-apis.md` |
+| Handling soft-deprecated APIs | `references/soft-deprecation.md` |
 | Previews | `references/previews.md` |
 | Instruments trace analysis | `references/trace-analysis.md` |
 | Instruments trace recording | `references/trace-recording.md` |
@@ -128,8 +130,10 @@ These are hard rules -- violations are always bugs:
 - [ ] Passed values never declared as `@State` or `@StateObject` (they ignore updates)
 - [ ] `@StateObject` for view-owned objects; `@ObservedObject` for injected
 - [ ] iOS 17+: `@State` with `@Observable`; `@Bindable` for injected observables needing bindings
-- [ ] `ForEach` uses stable identity (never `.indices` for dynamic content)
-- [ ] Constant number of views per `ForEach` element
+- [ ] `ForEach` uses stable identity (never `.indices`/`\.offset`; id outlives the view and isn't derived from mutable content)
+- [ ] Constant number of views per `ForEach` element; `List` rows are unary
+- [ ] No closures stored in custom `@Environment`/`@FocusedValue` keys
+- [ ] Custom `@Entry` default values are stable (no `Model()`/`Date()`/`UUID()` expressions)
 - [ ] `.animation(_:value:)` always includes the `value` parameter
 - [ ] `@FocusState` properties are `private`
 - [ ] No redundant `@FocusState` writes inside tap gesture handlers on `.focusable()` views
@@ -161,5 +165,7 @@ These are hard rules -- violations are always bugs:
 - `references/macos-views.md` -- HSplitView, Table, PasteButton, AppKit interop
 - `references/previews.md` -- `#Preview` macro, `@Previewable` (iOS 18+), preview traits, mock data patterns for self-contained previews
 - `references/text-patterns.md` -- Text initializer selection, verbatim vs localized
+- `references/localization.md` -- String Catalogs, `#bundle` for packages, `LocalizedStringResource`, locale-aware formatting, RTL layout, translator comments
+- `references/soft-deprecation.md` -- How to behave with soft-deprecated APIs (when to migrate, scoping rule, don't migrate during unrelated edits)
 - `references/trace-analysis.md` -- Parse Instruments `.trace` files via `scripts/analyze_trace.py`; interpret main-thread coverage, high-severity SwiftUI updates, hitch narratives, and map findings back to source files
 - `references/trace-recording.md` -- Record a new trace via `scripts/record_trace.py`: attach to a running app, launch one fresh, or capture a manually-stopped session; supports stop-file for agent-driven flows

--- a/swiftui-expert-skill/references/animation-advanced.md
+++ b/swiftui-expert-skill/references/animation-advanced.md
@@ -367,6 +367,31 @@ struct Wedge: Shape {
 
 > Source: "What's new in SwiftUI" (WWDC25, session 256)
 
+### When to Implement `animatableData` Manually
+
+Reach for an explicit `animatableData` (instead of the macro) when the interpolated value needs custom logic that doesn't map 1:1 to a stored property — normalization, clamping, or driving a derived value. For a deployment target of iOS 26+, use `AnimatableValues`; for earlier targets, use `AnimatablePair`.
+
+```swift
+// iOS 26+: keep phase in 0..<2π and clamp amplitude during interpolation
+struct WaveShape: Shape {
+    var amplitude: CGFloat
+    var phase: CGFloat
+    var maxAmplitude: CGFloat
+
+    var animatableData: AnimatableValues<CGFloat, CGFloat> {
+        get { AnimatableValues(amplitude, phase) }
+        set {
+            amplitude = min(max(newValue.value.0, 0), maxAmplitude)
+            phase = newValue.value.1.truncatingRemainder(dividingBy: 2 * .pi)
+        }
+    }
+
+    func path(in rect: CGRect) -> Path { /* ... */ }
+}
+```
+
+On earlier deployment targets, the same logic uses `AnimatablePair` with `newValue.first` / `newValue.second`.
+
 ---
 
 ## Quick Reference

--- a/swiftui-expert-skill/references/latest-apis.md
+++ b/swiftui-expert-skill/references/latest-apis.md
@@ -2,6 +2,8 @@
 
 > Based on a comparison of Apple's documentation using the Sosumi MCP, we found the latest recommended APIs to use.
 
+> This file lists *what* the modern replacements are. For *how to behave* when you find a soft-deprecated API — when to migrate, when to leave it alone, and the scoping rule for unrelated edits — see `references/soft-deprecation.md`. To refresh this list after a new SDK release, run the maintenance skill at `.agents/skills/update-swiftui-apis/SKILL.md`.
+
 ## Table of Contents
 - [Always Use (iOS 15+)](#always-use-ios-15)
 - [When Targeting iOS 16+](#when-targeting-ios-16)

--- a/swiftui-expert-skill/references/list-patterns.md
+++ b/swiftui-expert-skill/references/list-patterns.md
@@ -89,7 +89,7 @@ ForEach(items) { item in
     AnyView(item.isSpecial ? SpecialRow(item: item) : RegularRow(item: item))
 }
 
-// Good - Create a unified row view
+// Good - Create a unified row view with a single top-level container
 ForEach(items) { item in
     ItemRow(item: item)
 }
@@ -98,16 +98,36 @@ struct ItemRow: View {
     let item: Item
 
     var body: some View {
-        if item.isSpecial {
-            SpecialRow(item: item)
-        } else {
-            RegularRow(item: item)
+        // The VStack keeps the row "unary" (one top-level view) so the
+        // List can template row ids without evaluating every row's body.
+        VStack {
+            if item.isSpecial {
+                SpecialRow(item: item)
+            } else {
+                RegularRow(item: item)
+            }
         }
     }
 }
 ```
 
 **Why**: Stable identity is critical for performance and animations. Unstable identity causes excessive diffing, broken animations, and potential crashes.
+
+### Prefer unary rows in `List`
+
+`List` needs the identity of every row up front. When each row's body produces a **single top-level view** (a "unary" row), SwiftUI can template the row id from the `ForEach` element's id alone, without running each row's `body`. When the body branches between different top-level shapes — a bare top-level `switch`, a top-level `if` without `else`, or an `AnyView` — structural identity varies per row, so SwiftUI falls back to evaluating every row's body just to compute ids. That cost scales with the number of rows.
+
+The fix is to wrap branching content in any single-root container (`VStack`, `HStack`, `ZStack`, or a custom wrapper) so the row is always exactly one top-level view, as shown above. A top-level `if` without an `else` is also "multi" (0 or 1 views); if some elements shouldn't be rows at all, filter the collection before it reaches the `ForEach` rather than producing a zero-view row.
+
+To find non-constant row builders in an existing app, launch with `-LogForEachSlowPath YES`; SwiftUI logs each `ForEach` inside a lazy container whose row body produces a non-constant number of views.
+
+### Keep ids stable, unique, and cheap
+
+Three more identity rules that prevent subtle bugs:
+
+- **The id must outlive the view and not change on edit.** Don't derive `id` from a mutable property (e.g. `var id: String { title }`). Editing the title changes the id, so SwiftUI treats it as a removal plus insertion — focus and per-row state are lost mid-edit. Use a stable `let id: UUID` or a server-assigned key.
+- **Don't synthesize a fresh id inside `body`.** `ForEach(items.map { Item(title: $0) })` creates new `UUID`s on every body pass, so the whole collection reads as replaced every update. Create ids once in storage that outlives `body` (the model layer), not inline.
+- **Keep the id cheap to hash.** Avoid `id: \.self` on a large `Hashable` struct; hashing walks every field on every diff. Use a small primitive (`UUID`, `Int`, short `String`, `URL`) and still pass the full element to the row.
 
 ### Identifiable ID Must Be Truly Unique
 
@@ -133,21 +153,21 @@ struct Article: Identifiable {
 
 ## Enumerated Sequences
 
-**Always convert enumerated sequences to arrays. To be able to use them in a ForEach.**
+**Using `.enumerated()` is fine; the index just must not be the identity.** Using `\.offset` as the id is the same anti-pattern as `\.self` on `items.indices` — the id becomes the position, not the element, so inserts and reorders reset row state and break animations. Keep the element's own identity as the id and treat the index as ordinary row data.
 
 ```swift
-let items = ["A", "B", "C"]
-
-// Correct
-ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-    Text("\(index): \(item)")
+// Wrong - offset is the position, not the element
+ForEach(items.enumerated(), id: \.offset) { index, item in
+    ItemRow(number: index + 1, item: item)
 }
 
-// Wrong - Doesn't compile, enumerated() isn't an array
-ForEach(items.enumerated(), id: \.offset) { index, item in
-    Text("\(index): \(item)")
+// Correct - id comes from the element; index is just data
+ForEach(items.enumerated(), id: \.element.id) { index, item in
+    ItemRow(number: index + 1, item: item)
 }
 ```
+
+**No `Array(...)` wrapper is needed on Swift 6.1+.** As of Swift 6.1, the sequence returned by `.enumerated()` conditionally conforms to `RandomAccessCollection` when the base collection does, so `ForEach` accepts it directly. On earlier toolchains, wrap it in `Array(...)`. Favor the direct form in new code — it avoids an eager copy on every body evaluation.
 
 ## List with Custom Styling
 
@@ -432,12 +452,13 @@ Table(people) { /* columns */ }
 
 ## Summary Checklist
 
-- [ ] ForEach uses stable identity (never `.indices` for dynamic content)
+- [ ] ForEach uses stable identity (never `.indices` or `\.offset` for dynamic content)
 - [ ] Identifiable IDs are truly unique across all items
-- [ ] Constant number of views per ForEach element
+- [ ] id is stable across edits (not derived from a mutable property), created outside `body`, and cheap to hash
+- [ ] Constant number of views per ForEach element; rows are unary (single top-level view)
 - [ ] No inline filtering in ForEach (prefilter and cache instead)
 - [ ] No `AnyView` in list rows
-- [ ] Don't convert enumerated sequences to arrays
+- [ ] `.enumerated()` uses the element's id (not `\.offset`); no `Array(...)` wrapper needed on Swift 6.1+
 - [ ] Use `.refreshable` for pull-to-refresh
 - [ ] Use `ContentUnavailableView` for empty states (iOS 17+)
 - [ ] Use `.scrollContentBackground(.hidden)` for custom list backgrounds

--- a/swiftui-expert-skill/references/localization.md
+++ b/swiftui-expert-skill/references/localization.md
@@ -1,0 +1,194 @@
+# SwiftUI Localization Reference
+
+Guidance for user-facing text: `Text`, `Button`, `Label`, navigation/toolbar titles, alerts, and types that carry localizable strings. For the narrower "verbatim vs localized" decision on a single `Text`, see `references/text-patterns.md`.
+
+## Table of Contents
+
+- [SwiftUI Localizes String Literals Automatically](#swiftui-localizes-string-literals-automatically)
+- [String Catalogs](#string-catalogs)
+- [Bundle for Swift Packages and Frameworks](#bundle-for-swift-packages-and-frameworks)
+- [Localizing Variables and Custom Types](#localizing-variables-and-custom-types)
+- [LocalizedStringResource for Non-View Types](#localizedstringresource-for-non-view-types)
+- [Interpolation vs Concatenation](#interpolation-vs-concatenation)
+- [Casing](#casing)
+- [Formatting Dates, Numbers, and Currencies](#formatting-dates-numbers-and-currencies)
+- [Layout for Localization](#layout-for-localization)
+- [Reading the Current Locale](#reading-the-current-locale)
+- [String(localized:) Outside SwiftUI Views](#stringlocalized-outside-swiftui-views)
+- [Comments for Translators](#comments-for-translators)
+
+## SwiftUI Localizes String Literals Automatically
+
+Initializers that accept `LocalizedStringKey` (`Text`, `Button`, `Label`, `.navigationTitle`, alert titles, and so on) treat string literals as localization keys automatically. Do not wrap literals in `NSLocalizedString`, `String(localized:)`, or `LocalizedStringResource` — that resolves the string eagerly and ignores `\.locale` overrides.
+
+```swift
+// AVOID: double work, and resolves eagerly
+Text(String(localized: "start_workout"))
+
+// PREFER: pass the literal directly
+Text("start_workout")
+```
+
+Both opaque keys (`"start_workout"`) and natural-language strings (`"Start Workout"`) work as keys — pick whichever convention the project already uses. Use `Text(verbatim:)` only to opt a literal out of localization (e.g. a debug label interpolating a runtime value). When the argument is already a `String` variable, `Text(value)` calls the `StringProtocol` overload and skips localization on its own.
+
+## String Catalogs
+
+Most projects localize through String Catalogs (`.xcstrings`). Each build syncs new keys from code into the catalog, but the catalog file must already exist — Xcode doesn't create one automatically. If a project already uses `.strings` / `.stringsdict`, add new strings there rather than migrating. Route groups of strings to a specific catalog with `tableName:`.
+
+```swift
+Text("Explore", tableName: "Navigation",
+     comment: "Tab bar item title for the Explore screen.")
+```
+
+## Bundle for Swift Packages and Frameworks
+
+Apps, app extensions, and XPC services are their own main bundle, so `bundle` can be omitted. Frameworks and Swift packages need an explicit `bundle:` — without one, SwiftUI looks up strings in `Bundle.main`, the lookup fails silently, and the string appears unlocalized at runtime.
+
+```swift
+// AVOID (inside a framework/package): searches the app's catalog
+Text("Save to Favorites")
+
+// PREFER: #bundle resolves to the current target's bundle
+Text("Save to Favorites", bundle: #bundle,
+     comment: "Button to bookmark a recipe.")
+```
+
+`#bundle` is the preferred form; `Bundle.module` and `Bundle(for:)` still work but are older patterns.
+
+## Localizing Variables and Custom Types
+
+A `String` variable passed to `Text` runs the `StringProtocol` overload and is **not** localized. Wrapping it in `LocalizedStringKey(_:)` doesn't help — Xcode can't extract a literal from a runtime value, so nothing lands in the catalog. To localize a value chosen from a known set, model it with a type that exposes `LocalizedStringResource`:
+
+```swift
+enum Category {
+    case appetizers, mains, desserts
+    var name: LocalizedStringResource {
+        switch self {
+        case .appetizers: "Appetizers"
+        case .mains: "Mains"
+        case .desserts: "Desserts"
+        }
+    }
+}
+
+Text(category.name)
+```
+
+When a view or model exposes user-facing text, type the property as `LocalizedStringKey` or `LocalizedStringResource` rather than `String`. Every SwiftUI view that takes localized text accepts both, so deferring resolution costs nothing at the display site and preserves locale/bundle context.
+
+## LocalizedStringResource for Non-View Types
+
+When a non-view type carries user-facing text — a model object, a tip, a queued notification — use `LocalizedStringResource` instead of `String`. It defers resolution to display time, so it honors the locale active when the value actually renders, not when it was created.
+
+```swift
+// AVOID: resolved at creation time, can't re-render in another locale
+struct Tip { let headline: String }
+let tip = Tip(headline: String(localized: "Tip of the Day"))
+
+// PREFER: resolution deferred to display time
+struct Tip { let headline: LocalizedStringResource }
+let tip = Tip(headline: "Tip of the Day")
+```
+
+Apply this when designing new types or changing user-facing text — don't sweep through existing `String` properties as part of unrelated edits.
+
+## Interpolation vs Concatenation
+
+String interpolation preserves `LocalizedStringKey` and produces a format string in the catalog (e.g. `"Welcome, %@"`). Concatenation with `+` produces a plain `String` and is not localized. Never glue separately localized fragments into a sentence — word order varies across languages.
+
+```swift
+// AVOID: + produces String; sentence assembly breaks word order
+Text("Error: " + statusMessage)
+Text(String(localized: "Created by")) + Text(" ") + Text(authorName)
+
+// PREFER: one interpolated string translators can rearrange
+Text("Error: \(statusMessage)")
+Text("Created by \(authorName)")
+```
+
+## Casing
+
+Bake the desired case into the string rather than transforming at runtime via `.textCase(_:)`, `.localizedUppercase`, or `.localizedCapitalized`. A runtime transform forces the same casing on every translation, leaving translators no room to adjust per language.
+
+```swift
+// AVOID
+Text("Section Header").textCase(.uppercase)
+
+// PREFER
+Text("SECTION HEADER")
+```
+
+This applies to localized strings; display user-entered text as-is. If a transform is unavoidable, prefer `.localizedUppercase` / `.localizedCapitalized`, which honor the user's locale.
+
+## Formatting Dates, Numbers, and Currencies
+
+Use `Text`'s `format:` parameter or `.formatted()` instead of `DateFormatter` / `NumberFormatter` with hardcoded format strings. Format styles adapt to the user's locale; hardcoded format strings don't.
+
+```swift
+// AVOID
+let f = DateFormatter(); f.dateFormat = "MM/dd/yyyy"
+Text(f.string(from: workout.date))
+Text("$\(product.price, specifier: "%.2f")")
+
+// PREFER
+Text(workout.date, format: .dateTime.month().day().year())
+Text(product.price, format: .currency(code: store.currencyCode))
+```
+
+Field components (`.month()`, `.day()`) choose which fields appear; the locale decides the order. For lists, `Array.formatted()` inserts locale-correct separators and conjunctions instead of `joined(separator:)`. When `DateFormatter` is genuinely unavoidable, use `setLocalizedDateFormatFromTemplate(_:)` rather than assigning `dateFormat`.
+
+## Layout for Localization
+
+- Use `.leading` / `.trailing` instead of `.left` / `.right` — they flip for right-to-left locales.
+- Don't hardcode frame widths/heights for text; translations vary in length and scripts vary in height. Use `ViewThatFits` when a layout might not fit longer translations.
+- Use text styles (`.body`, `.headline`) rather than fixed point sizes, so line height adapts per script.
+
+```swift
+// PREFER
+Text(recipe.title)
+    .frame(maxWidth: .infinity, alignment: .leading)
+
+ViewThatFits {
+    HStack { actionButtons }
+    VStack { actionButtons }
+}
+```
+
+## Reading the Current Locale
+
+Use `@Environment(\.locale)` for locale-dependent logic in views, not `Locale.current` — the environment respects preview overrides and per-view injection.
+
+## String(localized:) Outside SwiftUI Views
+
+When you need a localized `String` outside a view, use `String(localized:)`, not `NSLocalizedString`. Don't interpolate inside `NSLocalizedString` — Xcode extracts keys from literals at build time and can't extract interpolated values. `String(localized:)` supports interpolation (it extracts the format string and treats values as runtime arguments) and is preferred over `String(format:)`, which always renders digits as 0–9 regardless of locale.
+
+```swift
+// PREFER
+let title = String(localized: "activity_summary", comment: "Dashboard header")
+```
+
+## Comments for Translators
+
+Add a `comment:` describing the UI element and its purpose, especially for ambiguous strings. For interpolated strings, describe each placeholder by position — translators don't see Swift variable names. Comments can live at the call site or in the String Catalog's per-string Comment field; keep one source of truth per string.
+
+```swift
+// AVOID: "Edit" could be a noun or a verb
+Text("Edit")
+
+// PREFER
+Text("Edit", comment: "Toolbar button that enters editing mode for the list.")
+Text("Completed \(count) of \(total)",
+     comment: "Progress label — first variable is finished items, second is the total.")
+```
+
+## Summary Checklist
+
+- [ ] String literals passed directly to `Text`/`Button`/`Label` (not wrapped in `NSLocalizedString`/`String(localized:)`)
+- [ ] `bundle: #bundle` on user-facing strings inside frameworks and Swift packages
+- [ ] User-facing text on models/non-view types typed as `LocalizedStringResource`, not `String`
+- [ ] Interpolation (not `+`) for dynamic strings; no sentence assembly from fragments
+- [ ] Case baked into the string, not applied via `.textCase`
+- [ ] Dates/numbers/currencies use `format:` / `.formatted()` with locale-aware styles
+- [ ] `.leading`/`.trailing` (not `.left`/`.right`); no hardcoded text frame sizes
+- [ ] `@Environment(\.locale)` for locale logic in views
+- [ ] `comment:` provided for ambiguous strings and interpolated placeholders

--- a/swiftui-expert-skill/references/performance-patterns.md
+++ b/swiftui-expert-skill/references/performance-patterns.md
@@ -232,7 +232,21 @@ struct ItemRow: View {
 }
 ```
 
-**Avoid storing frequently-changing values in the environment.** Even when a view doesn't read the changed key, SwiftUI still checks all environment readers. This cost adds up with many views and frequent updates (geometry values, timers).
+**Avoid storing frequently-changing values in the environment.** Every write to *any* environment key forces every view that reads *any* key in that subtree to be checked. So a high-frequency value (scroll offset, window/container size, drag translation, per-frame animation progress, timer ticks, hover location) flowing into an `@Entry` or `.environment(\.key, value)` becomes an invalidation storm.
+
+Instead, hold the value in an `@Observable` model and expose a **coarsened** value — a boolean threshold rather than the raw measurement — so views invalidate only when crossing a meaningful boundary:
+
+```swift
+@MainActor @Observable
+final class ViewportModel {
+    var width: CGFloat = 0 { didSet { isWide = width > 600 } }
+    private(set) var isWide = false   // readers invalidate only when this flips
+}
+```
+
+The same shape applies per row in a list: storing the raw offset on a model and having every row read it still invalidates all visible rows every frame. Give each item its own `@Observable` whose properties track only that item's derived state (e.g. `isVisible`), so each row invalidates at most twice (enter/leave) regardless of scroll speed — see item #10 below.
+
+For purely visual effects driven by scroll position (opacity, scale, rotation), prefer `scrollTransition` or `visualEffect(in:)` — they push the per-frame work to the renderer and skip body re-evaluation entirely. Reach for the `@Observable` + coarsening pattern only when the scroll-derived value must drive non-rendering logic (model updates, prefetches, sibling state).
 
 > Source: "Optimize SwiftUI performance with Instruments" (WWDC25, session 306)
 

--- a/swiftui-expert-skill/references/soft-deprecation.md
+++ b/swiftui-expert-skill/references/soft-deprecation.md
@@ -1,0 +1,39 @@
+# Handling Soft-Deprecated APIs
+
+This file covers *how to behave* when you encounter soft-deprecated SwiftUI APIs. For the actual list of deprecated-to-modern transitions, see `references/latest-apis.md`.
+
+## What "soft-deprecated" means
+
+A soft-deprecated API is marked deprecated in the SDK headers but with a placeholder deprecation version (`100000.0`) that suppresses compiler warnings. It still compiles and works correctly — it just signals that the API shouldn't be used in new code. Examples include `NavigationView` (use `NavigationStack` / `NavigationSplitView`), `ActionSheet` / `Alert` (use the `.confirmationDialog` / `.alert` modifiers), `MagnificationGesture` (renamed `MagnifyGesture`), and `PresentationMode` (use `\.dismiss`).
+
+Because these still work, treat them as **informational**, not urgent.
+
+## Scoping rule — read this first
+
+All soft-deprecation guidance is scoped to the code you are **directly modifying**. If a file contains several views and the task touches only one, the other views are out of scope.
+
+- Only discuss the view(s) you actually edited.
+- Do not mention, flag, or offer to migrate soft-deprecated APIs in code you weren't asked to change — including trailing "while I'm here, want me to migrate `OtherView`?" questions.
+- This takes precedence over any prompt asking for "observations" or "other notes."
+
+Mentioning soft-deprecated APIs in untouched code creates noise, distracts from the task, and pressures the user into unrelated work.
+
+## When generating new code
+
+Never introduce a new usage of a soft-deprecated API. If you're unsure whether an API is soft-deprecated, check `references/latest-apis.md` before recommending it — any API that worked in a prior release could have been soft-deprecated since.
+
+## When asked to review, refactor, modernize, or clean up
+
+Point out soft-deprecated APIs in the code under review and suggest the modern replacement. Keep the tone informational — these still compile and run, so frame migration as an improvement, not a bug fix.
+
+## When asked to add a feature or fix a bug
+
+If the view you're editing already uses a soft-deprecated API, **keep it as-is** in your change. Don't silently swap `NavigationView` for `NavigationStack` while adding a search bar — that produces unexpected diffs, risks regressions (state resets, navigation behavior changes), and makes the change harder to review. After delivering the requested change, you may add a brief one-line offer to migrate as a separate step.
+
+If a *different* view in the same file uses a soft-deprecated API, ignore it entirely (see the scoping rule).
+
+## General guidance
+
+- Never introduce new usages of soft-deprecated APIs in code written from scratch.
+- Don't proactively scan a codebase for soft-deprecated APIs — only notice them when they appear in code you're directly modifying for the user's request.
+- Migrations are real edits with behavioral risk; they belong in their own focused change, not bundled into unrelated work.

--- a/swiftui-expert-skill/references/state-management.md
+++ b/swiftui-expert-skill/references/state-management.md
@@ -5,6 +5,8 @@
 - [Property Wrapper Selection Guide](#property-wrapper-selection-guide)
 - [@State](#state)
 - [Property Wrappers Inside @Observable Classes](#property-wrappers-inside-observable-classes)
+- [Make @Observable Property Types Equatable](#make-observable-property-types-equatable)
+- [@Observable Dependency Granularity](#observable-dependency-granularity)
 - [@Binding](#binding)
 - [@FocusState](#focusstate)
 - [@StateObject vs @ObservedObject (Legacy - Pre-iOS 17)](#stateobject-vs-observedobject-legacy---pre-ios-17)
@@ -104,6 +106,44 @@ This applies to **any** property wrapper used inside an `@Observable` class, inc
 
 **Never remove `@ObservationIgnored`** from property-wrapper properties in `@Observable` classes — doing so causes a compiler error.
 
+## Make @Observable Property Types Equatable
+
+The `@Observable` macro generates a setter that **skips invalidation when the new value equals the current one** — but only when it can compare them, which means only when the property's type is `Equatable`. Without that conformance, every assignment notifies observing views, even when the value is identical. This is an easy win for properties written frequently with the same value (polling, streaming updates, timers).
+
+```swift
+// AVOID: not Equatable — every assignment invalidates, even no-op writes
+enum DeliveryStatus { case placed, preparing, shipped, delivered }
+
+// PREFER: Equatable lets the generated setter short-circuit redundant writes
+enum DeliveryStatus: Equatable { case placed, preparing, shipped, delivered }
+```
+
+This applies to collection properties too: an `Array`/`Set`/`Dictionary` is only `Equatable` when its element type is, so a non-`Equatable` element defeats the short-circuit for the whole collection. (The check is emitted into the generated setter as user code, so it applies on every OS that supports `@Observable` when built with current Xcode.)
+
+This is distinct from `Equatable` *views* (see `references/performance-patterns.md`): that conformance lets SwiftUI skip a view's body; this one lets the model skip notifying observers in the first place.
+
+## @Observable Dependency Granularity
+
+Observation tracks reads at the **property** level, not the field level — so reading any part of a compound property establishes a dependency on the whole thing. Three common traps and their fixes:
+
+- **A computed property establishes dependencies transitively.** `var currentUser: User? { users.first { $0.id == currentID } }` reads `users` in its body, so any view reading `currentUser` depends on the entire `users` array. Renaming the access doesn't change what observation tracks.
+- **A struct-typed stored property drags the whole struct.** A view reading `session.user.name` depends on `session.user`; editing any other field of `user` invalidates it.
+- **An array/collection read drags the whole collection.** Reading one element establishes a dependency on the entire stored collection.
+
+```swift
+// PREFER: cache derived values as stored properties, kept in sync in didSet
+@MainActor @Observable
+final class AppState {
+    var users: [User] = [] { didSet { recomputeCurrentUser() } }
+    var currentID: User.ID? { didSet { recomputeCurrentUser() } }
+
+    private(set) var currentUser: User?
+    private func recomputeCurrentUser() { currentUser = users.first { $0.id == currentID } }
+}
+```
+
+For struct-typed properties, expose the fields the views actually read as individual properties on the model (each is then tracked separately). When many rows each observe several fields of their element, model each element as its own `@Observable` and have the parent **persist** the instances — see the per-item view model pattern in `references/performance-patterns.md`. Reading several already-narrow properties from one model is fine and does not need splitting.
+
 ## @Binding
 
 Use only when child view needs to **modify** parent's state. If child only reads the value, use `let` instead.
@@ -133,6 +173,25 @@ struct ChildView: View {
 ### When NOT to use @Binding
 
 - **Don't use `@Binding` for read-only values.** If the child only displays the value and never modifies it, use `let` instead. `@Binding` adds unnecessary overhead and implies a write contract that doesn't exist.
+
+### Prefer KeyPath Bindings Over Closure Bindings
+
+When you need a binding into a model, prefer a KeyPath/subscript-based binding over a hand-written `Binding(get:set:)` closure. A closure binding allocates a new closure each time `body` runs and can't be compared, which can trigger unnecessary invalidations.
+
+```swift
+// BAD - closure binding: heap allocation each body pass, defeats comparison
+let binding = Binding(
+    get: { model[scoreFor: player] },
+    set: { model[scoreFor: player] = $0 }
+)
+PlayerScoreRow(player: player, score: binding)
+
+// GOOD - project through a subscript with @Bindable
+@Bindable var model = model
+PlayerScoreRow(player: player, score: $model[scoreFor: player])
+```
+
+If no suitable subscript exists, add one (a labeled subscript reads as a clean projection into the model). Reserve closure bindings for cases where no key path or subscript can express the transform.
 
 ## @FocusState
 
@@ -294,7 +353,49 @@ struct ThemedView: View {
 }
 ```
 
-The `@Entry` macro replaces the manual `EnvironmentKey` conformance pattern. It also works with `TransactionValues`, `ContainerValues`, and `FocusedValues`.
+The `@Entry` macro replaces the manual `EnvironmentKey` conformance pattern. It also works with `Transaction`, `ContainerValues`, and `FocusedValues`.
+
+#### Never store closures in custom environment keys
+
+SwiftUI can't reliably compare function values, so a view that reads an environment key holding a closure invalidates on every environment write, even when nothing it cares about changed. Wrapping the closure in a struct doesn't help — the struct still contains an uncomparable closure. The fix is to eliminate the closure: store the data it would have captured as properties and expose the behavior via `callAsFunction` or a method.
+
+```swift
+// AVOID: closure in a custom environment key
+extension EnvironmentValues {
+    @Entry var submit: (String) -> Void = { _ in }
+}
+
+// PREFER: a defunctionalized struct (or an @Observable model)
+struct SubmitAction { func callAsFunction(_ draft: String) { /* ... */ } }
+extension EnvironmentValues {
+    @Entry var submit = SubmitAction()
+}
+```
+
+This rule is for **custom** keys. Framework action types designed to wrap a closure — `\.openURL`, `\.dismiss`, `\.refresh`, and similar — are the intended API and are fine.
+
+#### Keep @Entry default values stable
+
+`@Entry` wraps its default expression in a computed getter, so the default is re-evaluated on every read that falls back to it. If the expression returns a different result each time — a fresh reference like `Model()`, or a runtime value like `Date()` / `UUID()` — readers that use the default invalidate on every unrelated environment write.
+
+```swift
+// AVOID: re-allocates Model() on every fallback read
+extension EnvironmentValues {
+    @Entry var model = Model()
+}
+
+// PREFER: back the default with a stable value
+extension EnvironmentValues {
+    @Entry var model = _defaultModel
+    private static let _defaultModel = Model()
+}
+```
+
+Stable defaults (literals, enum cases, `nil`, or a `static let`-backed instance) need no fix. If readers test the default for an "empty" sentinel, prefer an optional `@Entry var model: Model?` and branch on `if let` instead.
+
+#### Remove unused @Environment reads
+
+Declaring `@Environment(\.someKey)` subscribes the view to that key even if `body` never uses the value, so every write to that key re-evaluates the view for nothing. If the wrapped value isn't referenced anywhere the body reaches, delete the declaration. (The type form `@Environment(Model.self)` is different — observation tracks at the property level, so an unused type-form declaration carries no live invalidation cost.)
 
 ### @Environment with @Observable (iOS 17+ - Preferred)
 
@@ -386,3 +487,6 @@ SwiftUI can't track changes through nested `ObservableObject` properties. Workar
 6. **Never declare passed values as `@State` or `@StateObject`**
 7. With `@Observable`, nested objects work fine; with `ObservableObject`, pass nested objects directly to child views
 8. **Always add `@ObservationIgnored` to property wrappers** (e.g., `@AppStorage`, `@SceneStorage`, `@Query`) inside `@Observable` classes — they conflict with the macro's property transformation
+9. **Prefer `Equatable` types for frequently-written `@Observable` properties** so the generated setter skips redundant invalidations
+10. **Never store closures in custom environment keys; keep `@Entry` defaults stable** (no `Model()`/`Date()` expressions)
+11. **Prefer KeyPath/subscript bindings over closure bindings**

--- a/swiftui-expert-skill/references/text-patterns.md
+++ b/swiftui-expert-skill/references/text-patterns.md
@@ -1,5 +1,7 @@
 # SwiftUI Text Patterns Reference
 
+> For broader localization guidance — String Catalogs, `#bundle` for packages, `LocalizedStringResource`, locale-aware formatting, RTL layout, and translator comments — see `references/localization.md`. This file covers only the verbatim-vs-localized decision for a single `Text`.
+
 ## Table of Contents
 
 - [Text Initialization: Verbatim vs Localized](#text-initialization-verbatim-vs-localized)

--- a/swiftui-expert-skill/references/view-structure.md
+++ b/swiftui-expert-skill/references/view-structure.md
@@ -3,12 +3,14 @@
 ## Table of Contents
 
 - [View Structure Principles](#view-structure-principles)
-- [Recommended View File Structure](#recommended-view-file-structure)
+- [View File Structure (optional readability suggestion)](#view-file-structure-optional-readability-suggestion)
 - [Struct or Method / Computed Property?](#struct-or-method--computed-property)
 - [Prefer Modifiers Over Conditional Views](#prefer-modifiers-over-conditional-views)
 - [Extract Subviews, Not Computed Properties](#extract-subviews-not-computed-properties)
 - [@ViewBuilder](#viewbuilder)
 - [Keep View Body Simple and Avoid High-Cost Operations](#keep-view-body-simple-and-avoid-high-cost-operations)
+- [Keep View `init` Cheap](#keep-view-init-cheap)
+- [Single-Child Group](#single-child-group)
 - [When to Extract Subviews](#when-to-extract-subviews)
 - [Container View Pattern](#container-view-pattern)
 - [Utilize Lazy Containers for Large Data Sets](#utilize-lazy-containers-for-large-data-sets)
@@ -26,16 +28,9 @@
 
 SwiftUI's diffing algorithm compares view hierarchies to determine what needs updating. Proper view composition directly impacts performance.
 
-## Recommended View File Structure
+## View File Structure (optional readability suggestion)
 
-Use a consistent order when declaring SwiftUI views:
-
-1. Environment Properties
-2. State Properties
-3. Private Properties
-4. Initializer (if needed)
-5. Body
-6. Computed Properties/Methods for Subviews
+Property ordering has no effect on correctness or performance, so treat this as a personal/team readability preference rather than a rule. Some developers find a consistent order easier to scan — for example, environment, then state, then passed-in properties, then `init`, body, and helper subviews. Adopt it only if your team wants the consistency; never reorder existing code solely to match it.
 
 ```swift
 struct ContentView: View {
@@ -175,7 +170,13 @@ Text("Hello")
     .foregroundStyle(isError ? .red : .primary)
 ```
 
+When writing new code, never reach for a `.if` modifier. When reviewing existing code that already uses one, point out the identity/animation risk and show the ternary alternative, but don't silently refactor it as part of an unrelated change — swapping it can alter behavior (state resets, transition timing) and belongs in its own focused edit.
+
 ## Extract Subviews, Not Computed Properties
+
+A view is SwiftUI's unit of invalidation. When an input changes, SwiftUI re-runs the body of the smallest enclosing **view type** that depends on it — every conditional, modifier chain, and string interpolation in that body, even if only one leaf actually depends on what changed. A computed property or `@ViewBuilder` helper is inlined into the parent's body, so it shares the parent's invalidation boundary and does not reduce update cost; it only reorganizes the code. A separate `View` type with narrow inputs becomes its own boundary and re-runs only when its own inputs change.
+
+This is why "split your body for readability" is also a performance tool — but only when you split into real `View` types, not computed properties.
 
 ### The Problem with @ViewBuilder Functions
 
@@ -244,6 +245,31 @@ struct ComplexSection: View {
 1. SwiftUI compares the `ComplexSection` struct (which has no properties)
 2. Since nothing changed, SwiftUI skips calling `ComplexSection.body`
 3. The complex view code never executes unnecessarily
+
+### Multi-section detail views
+
+The most common place this rule gets dropped is a detail screen with several distinct sections — `header + gallery + description + reviews`, `header + ingredients + steps`, `hero + specs + related`. The tempting shape is one big view with `private var header: some View`, `private var gallery: some View`, and so on. That shape shares one invalidation boundary, so a change that affects one section re-evaluates all of them. Factor each named section into its own `View` type that takes only the fields it renders, and keep the parent thin — it just composes the sections.
+
+```swift
+// PREFER: each section is its own type with narrow inputs.
+struct ProductDetailView: View {
+    let product: Product
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ProductHeader(name: product.name, price: product.price)
+                ProductGallery(images: product.imageURLs)
+                ProductDescription(text: product.descriptionText)
+                ProductReviews(average: product.averageStars, count: product.reviewCount)
+            }
+            .padding()
+        }
+    }
+}
+```
+
+This generalizes to every `*DetailView`: one `View` type per section, narrow inputs each, a thin parent that composes them. Small `@ViewBuilder` fragments reused two or three times within the same body are still fine — the rule targets factoring done for organization or to manage body length, where a real `View` type does the right thing.
 
 ## @ViewBuilder
 
@@ -330,7 +356,52 @@ General guidance:
 - avoid filtering, sorting, and mapping inline in `body`
 - avoid constructing expensive formatters in `body`
 - avoid heavy branching in large view trees
-- move data preparation into init, model layer, or dedicated helpers
+- move data preparation into the model layer or dedicated helpers
+
+## Keep View `init` Cheap
+
+A view's `init` runs every time the parent re-evaluates its body, which can be many times per second for views inside `List`, `LazyVStack`, scroll containers, or animated parents. Treat `init` as a constant-time copy of inputs into stored properties. Don't decode JSON, build a `DateFormatter`, touch the file system, or allocate large structures there — that work repeats on every parent body pass even when the inputs are identical.
+
+```swift
+// AVOID: decoding and formatting on every init
+init(rawJSON: Data, date: Date) {
+    self.summary = try! JSONDecoder().decode(WeatherSummary.self, from: rawJSON)
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    self.formattedDate = formatter.string(from: date)
+}
+
+// PREFER: take already-prepared values; format lazily in body
+let summary: WeatherSummary
+let date: Date
+
+var body: some View {
+    VStack {
+        Text(summary.headline)
+        Text(date, format: .dateTime.day().month().year())  // cached, locale-aware
+    }
+}
+```
+
+If a derived value genuinely needs to be computed once and kept, store it on an `@State`-owned `@Observable` model or compute it asynchronously in `.task` — not in `init`. `init` is not a one-time setup hook; it runs as often as the parent's body does.
+
+## Single-Child Group
+
+`Group { SomeView() }` — a `Group` with exactly one concrete child — wraps the view in an extra `Group<SomeView>` type for no visual benefit. Every modifier chained after it must be type-checked against that wrapper, adding avoidable type-checking overhead in long chains. Drop the `Group` and chain modifiers directly on the child.
+
+```swift
+// AVOID: single concrete child wrapped in Group
+Group { Text(status) }
+    .padding(.horizontal, 8)
+    .background(.thinMaterial, in: Capsule())
+
+// PREFER: chain directly on the child
+Text(status)
+    .padding(.horizontal, 8)
+    .background(.thinMaterial, in: Capsule())
+```
+
+The rule is specifically about one concrete view. A `Group` whose content is a `ForEach`, multiple sibling views, or an `if`/`else` (which produces `_ConditionalContent`) is doing real work — applying a shared modifier across siblings or both branches — and is fine.
 
 ## When to Extract Subviews
 
@@ -689,6 +760,8 @@ struct MapView: UIViewRepresentable {
 
 ### Debug SwiftUI Renderings
 
+> See `references/performance-patterns.md` (item #8) for the `_printChanges()` vs `_logChanges()` comparison and the `@self`/`@identity` output meaning. The snippets below show the call sites.
+
 If it is needed to debug render cycles and read console output you can leverage the `_printChanges()` or `_logChanges()` methods on `View`. These methods print information about when the view is being evaluated and what changes are triggering updates. This can be very helpful when your view body is called multiple times and you want to know why.
 
 ```swift
@@ -759,13 +832,14 @@ Ways to fix it:
 
 ## Summary Checklist
 
-- [ ] Follow a consistent view file structure (Environment → State → Private → Init → Body → Subviews)
 - [ ] Prefer modifiers over conditional views for state changes
 - [ ] Avoid `if`-based conditional modifier extensions (they break view identity)
 - [ ] Extract complex views into separate subviews, not computed properties
 - [ ] Keep views small for readability and performance
 - [ ] Use `@ViewBuilder` only where it actually adds value
 - [ ] Avoid heavy filtering, mapping, sorting, or formatter creation inside `body`
+- [ ] Keep view `init` cheap (no decoding/formatting/allocation; it runs on every parent body pass)
+- [ ] Avoid single-child `Group { OneView() }` (chain modifiers directly on the child)
 - [ ] Use lazy containers for large data sets
 - [ ] Container views use `@ViewBuilder let content: Content`
 - [ ] Prefer `overlay` / `background` for decoration and `ZStack` for peer composition


### PR DESCRIPTION
## Summary

Folds the strongest guidance from Apple's bundled Xcode 27 `swiftui-specialist` skill into our `swiftui-expert-skill`, aiming for the best of both: our breadth (layout, navigation, charts, macOS, previews, Instruments traces) plus Apple's depth on the invalidation model. Overlaps were de-duplicated with cross-links, and a few stale/conflicting points were corrected.

### Fixes / corrections
- `list-patterns`: `.enumerated()` no longer needs an `Array(...)` wrapper on Swift 6.1+, and the id must be the element's identity (`\.element.id`), not `\.offset` — the old advice was the same position-as-id trap as `.indices`.
- `list-patterns`: the "unified row" example is now unary (branching wrapped in a container) so `List` can template row ids.
- `view-structure`: softened the property-ordering mandate to an optional readability suggestion, per our own `AGENTS.md` (no formatting/linting rules).

### Sharpened
- `view-structure`: invalidation-boundary framing for extracting subviews; multi-section detail-view anti-pattern; "don't auto-refactor an existing `.if` during unrelated work" review note.
- `performance-patterns`: full rapidly-updating-environment pattern (coarsened `@Observable` thresholds, per-item models, `scrollTransition`/`visualEffect`).
- `animation-advanced`: when to implement `animatableData` manually; `AnimatableValues` (iOS 26+) vs `AnimatablePair`.

### Added
- `state-management`: make `@Observable` property types `Equatable` (setter short-circuit), per-property observation granularity traps + fixes, KeyPath bindings over closure bindings, no closures in custom environment keys, stable `@Entry` defaults, removing unused `@Environment` reads.
- `view-structure`: keep view `init` cheap; single-child `Group` anti-pattern.
- `list-patterns`: unary vs multi rows, `-LogForEachSlowPath`, stable/cheap/outliving ids.
- New `references/localization.md` and `references/soft-deprecation.md`.
- `SKILL.md`: Topic Router rows, References list, Correctness Checklist, and trigger description updated for the new coverage.

### Notes / follow-ups
- The deprecated-API data in `references/latest-apis.md` was not hand-edited; refreshing it against the iOS 27 SDK should be run through the existing `.agents/skills/update-swiftui-apis` maintenance skill (Sosumi-driven) as a separate change. A behavioral cross-reference to the new `soft-deprecation.md` was added.
- All guidance was checked against `AGENTS.md` (SwiftUI-only, factual not architectural, optimizations framed as suggestions).

## Test plan
- [ ] Skim `git diff` for tone/accuracy and confirm no contradictions with existing sections
- [ ] Verify all `references/*.md` links in `SKILL.md` resolve (they do)
- [ ] Confirm TOC anchors match the new headings in `state-management.md` and `view-structure.md`
- [ ] Optional: run the skill-creator description-optimization loop on the updated `SKILL.md` description