### PR TITLE
ci: bump workflow actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -116,7 +116,7 @@ jobs:
           git push
 
       - name: Create tag and GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           generate_release_notes: true

--- a/.github/workflows/sync-readme-references.yml
+++ b/.github/workflows/sync-readme-references.yml
@@ -13,14 +13,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Sync README structure
         run: node .github/scripts/sync-readme.js


### PR DESCRIPTION
## Summary

The `4.0.0` release run logged a GitHub warning that several actions still use the deprecated Node.js 20 runtime, which is being phased out on GitHub-hosted runners. This bumps them to the current Node 24 majors.

- `actions/checkout` `v4` → `v6` (both `release.yml` and `sync-readme-references.yml`)
- `actions/setup-node` `v4` → `v6`, and the script Node version `20` → `24` in `sync-readme-references.yml`
- `softprops/action-gh-release` `v2` → `v3` in `release.yml`

No workflow logic changed — only action versions.

## Test plan
- [ ] `sync-readme-references` runs on this PR (it triggers on `swiftui-expert-skill/references/**`, so it won't run here — no reference files changed)
- [ ] Next `Release` dispatch completes without the Node 20 deprecation annotation