### PR TITLE
fix(trace-recording)!: protect sensitive recording data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,14 +31,19 @@ This document provides guidance for AI agents working with this skill to ensure 
 
 **Exception**: Suggest separating business logic for testability without enforcing how.
 
-### 4. No Tool-Specific Instructions
-**Agents cannot use external tools.** Do not include:
-- Xcode Instruments profiling instructions
-- Debugging tool usage
-- IDE-specific features
-- Command-line tool usage beyond basic git
+### 4. Keep Tooling SwiftUI-Specific and Consent-Aware
+The skill includes focused Instruments tooling for SwiftUI performance work.
+Tool-specific instructions are allowed only when they directly support the
+bundled trace recording and analysis workflows. Do not add unrelated IDE,
+debugging, build-system, or general command-line guidance.
 
-**Exception**: Mention that users can profile with Instruments if performance issues arise, but don't provide detailed instructions.
+Agents using the trace tooling must:
+- Prefer app-scoped `--attach` or `--launch` recordings.
+- Explain the privacy implications and obtain explicit user approval before a
+  system-wide recording.
+- Pass `--allow-system-wide-recording` with `--all-processes` after approval.
+- Avoid exposing environment-variable values or other secrets in output.
+- Treat trace files and extracted logs as potentially sensitive user data.
 
 ## Content Guidelines
 
@@ -76,7 +81,7 @@ This document provides guidance for AI agents working with this skill to ensure 
 - Swift concurrency deep dives (actors, sendable, etc.)
 - Code formatting and style rules
 - Architectural patterns and mandates
-- Tool usage instructions (Instruments, debuggers)
+- Tool usage unrelated to the bundled SwiftUI Instruments workflows
 - File organization requirements
 - Testing frameworks and patterns
 - Build system configuration
@@ -92,7 +97,7 @@ This document provides guidance for AI agents working with this skill to ensure 
 ### Avoid Prescriptive Language:
 - ❌ "You must organize properties in this order"
 - ❌ "Always use MVVM architecture"
-- ❌ "Profile with Instruments following these steps"
+- ❌ "Run unrelated debugger or build-system commands"
 - ❌ "Structure your project like this"
 
 ## Examples
@@ -116,10 +121,9 @@ When you encounter `UIImage(data:)`, consider suggesting image downsampling as a
 3. Body
 4. Helpers
 
-**Use Instruments to profile:**
-1. Open Instruments
-2. Select SwiftUI template
-3. Record and analyze...
+**Use unrelated tooling:**
+1. Reconfigure the build system
+2. Run a general-purpose debugger workflow
 ```
 
 ## Updating the Skill

--- a/swiftui-expert-skill/references/trace-recording.md
+++ b/swiftui-expert-skill/references/trace-recording.md
@@ -10,6 +10,21 @@ The bundled `scripts/record_trace.py` wraps `xctrace record` with:
 - **Manual stop** via Ctrl+C, a stop-file, or `--time-limit`.
 - JSON discovery for devices and templates.
 - Normal Python exit codes so an agent can orchestrate.
+- Redacted command logging for values passed through `--env`.
+- An explicit acknowledgement gate for system-wide recordings.
+
+## Privacy and consent
+
+Prefer `--attach` or `--launch`, which limits collection to the app being
+diagnosed. A system-wide recording can capture activity and metadata from
+unrelated applications. Before using `--all-processes`, explain that scope to
+the user and obtain their explicit approval. Then pass
+`--allow-system-wide-recording` to record that acknowledgement in the command.
+
+Values passed through `--env KEY=VALUE` are forwarded to `xctrace`, but the
+wrapper redacts each value from its displayed command. Avoid placing secrets on
+command lines when a safer launch configuration is available, because other
+local process-inspection tools may still expose process arguments.
 
 ## Typical flows
 
@@ -105,6 +120,14 @@ the user to connect/unlock/trust the device before recording.
 
 For ad-hoc hang hunting on any target, `Time Profiler` or
 `Animation Hitches` alone may be enough.
+
+For an explicitly approved system-wide recording:
+
+```bash
+python3 "${SKILL_DIR}/scripts/record_trace.py" \
+  --all-processes --allow-system-wide-recording \
+  --time-limit 30s --output ~/Desktop/system-wide.trace
+```
 
 ## Chaining into analysis
 

--- a/swiftui-expert-skill/scripts/record_trace.py
+++ b/swiftui-expert-skill/scripts/record_trace.py
@@ -64,6 +64,11 @@ def main(argv: list[str] | None = None) -> int:
                         help="Attach to a running process by pid or name.")
     target.add_argument("--all-processes", action="store_true",
                         help="Record every process (system-wide).")
+    parser.add_argument(
+        "--allow-system-wide-recording",
+        action="store_true",
+        help="Acknowledge that --all-processes may capture data from unrelated apps.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -86,6 +91,22 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 2
 
+    if args.all_processes and not args.allow_system_wide_recording:
+        print(
+            "error: --all-processes may capture sensitive data from unrelated apps. "
+            "Review the recording scope and pass --allow-system-wide-recording "
+            "to confirm.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.allow_system_wide_recording and not args.all_processes:
+        print(
+            "error: --allow-system-wide-recording only applies with --all-processes.",
+            file=sys.stderr,
+        )
+        return 2
+
     output = args.output or Path.cwd() / _default_trace_name(args.template)
     if output.exists():
         print(f"error: output already exists: {output}", file=sys.stderr)
@@ -105,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.time_limit:
         stop_hints.append(f"after {args.time_limit}")
     print(f"[record] stop via: {', '.join(stop_hints)}", flush=True)
-    print(f"[record] cmd: {' '.join(_shell_quote(c) for c in cmd)}", flush=True)
+    print(f"[record] cmd: {_format_command_for_display(cmd)}", flush=True)
 
     # Start xctrace in its own process group so we can signal cleanly.
     proc = subprocess.Popen(cmd, start_new_session=True)
@@ -246,6 +267,21 @@ def _shell_quote(s: str) -> str:
     if re.match(r"^[A-Za-z0-9_./:=@-]+$", s):
         return s
     return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _format_command_for_display(cmd: list[str]) -> str:
+    """Render a command for logs without exposing launched-app env values."""
+    display: list[str] = []
+    redact_next = False
+    for arg in cmd:
+        if redact_next:
+            key = arg.split("=", 1)[0]
+            display.append(f"{key}=<redacted>" if key else "<redacted>")
+            redact_next = False
+            continue
+        display.append(arg)
+        redact_next = arg == "--env"
+    return " ".join(_shell_quote(arg) for arg in display)
 
 
 if __name__ == "__main__":

--- a/tests/test_record_trace.py
+++ b/tests/test_record_trace.py
@@ -1,0 +1,65 @@
+"""Security-focused tests for the Instruments recording wrapper."""
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "swiftui-expert-skill"
+    / "scripts"
+    / "record_trace.py"
+)
+SPEC = importlib.util.spec_from_file_location("record_trace", SCRIPT)
+assert SPEC and SPEC.loader
+record_trace = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(record_trace)
+
+
+class CommandDisplayTests(unittest.TestCase):
+    def test_redacts_every_environment_value(self) -> None:
+        cmd = [
+            "xctrace", "record",
+            "--env", "API_TOKEN=super-secret",
+            "--env", "DISPLAY_NAME=Jane Doe",
+            "--launch", "--", "/tmp/Test.app",
+        ]
+
+        displayed = record_trace._format_command_for_display(cmd)
+
+        self.assertNotIn("super-secret", displayed)
+        self.assertNotIn("Jane Doe", displayed)
+        self.assertIn("API_TOKEN=<redacted>", displayed)
+        self.assertIn("DISPLAY_NAME=<redacted>", displayed)
+
+
+class SystemWideConsentTests(unittest.TestCase):
+    def test_all_processes_requires_explicit_acknowledgement(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), mock.patch.object(
+            record_trace.subprocess, "Popen"
+        ) as popen:
+            result = record_trace.main(["--all-processes"])
+
+        self.assertEqual(2, result)
+        self.assertIn("--allow-system-wide-recording", stderr.getvalue())
+        popen.assert_not_called()
+
+    def test_acknowledgement_is_rejected_without_all_processes(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            result = record_trace.main(
+                ["--attach", "TestApp", "--allow-system-wide-recording"]
+            )
+
+        self.assertEqual(2, result)
+        self.assertIn("only applies with --all-processes", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Redact values supplied through `--env` from the displayed `xctrace` command while continuing to forward the original values to the subprocess.
- Require `--allow-system-wide-recording` whenever `--all-processes` is used, preventing accidental system-wide capture without an explicit acknowledgement.
- Document the privacy implications of system-wide traces and command-line environment values.
- Reconcile `AGENTS.md` with the repository's shipped Instruments workflows and add consent-aware handling rules.
- Add focused unit tests for environment-value redaction and the system-wide recording gate.

## Security impact

This prevents launched-app environment values from being copied into terminal logs or agent transcripts. It also changes system-wide recording from an implicit capability to an explicitly acknowledged operation because those traces may contain activity from unrelated applications.

## Breaking change

Existing calls that use `--all-processes` must now also pass `--allow-system-wide-recording` after the user approves the broader recording scope.

## Validation

- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile swiftui-expert-skill/scripts/record_trace.py tests/test_record_trace.py`
- `git diff --check`

All checks pass.
