### PR TITLE
Use PNG logo in Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "repository": "https://github.com/AvdLee/SwiftUI-Agent-Skill",
   "license": "MIT",
-  "logo": "assets/logo.svg",
+  "logo": "skills/swiftui-expert-skill/assets/logo.png",
   "keywords": [
     "swift",
     "swiftui",


### PR DESCRIPTION
The live Cursor Marketplace listing shows a generic package icon. The manifest referenced `assets/logo.svg`; marketplace surfaces render PNGs reliably (same fix as the OpenAI listing), so this points the logo at `skills/swiftui-expert-skill/assets/logo.png` instead.